### PR TITLE
Creates the language array with empty strings to avoid crashing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -479,6 +479,11 @@ int loadLanguage(char *lang) {
 	// allocate new language strings
 	language = (char **) calloc(NUMLANGENTRIES,sizeof(char *));
 
+	// Allocate an emptry string for each possible language entry
+	for (c = 0; c < NUMLANGENTRIES; c++) {
+		language[c] = (char *)calloc(1, sizeof(char));
+	}
+
 	// read file
 	Uint32 line;
 	for( line=1; !feof(fp); ) {


### PR DESCRIPTION
Tested and the game no longer crashes if the tooltip texts  in the miscellaneous menu are missing.