### PR TITLE
Chest types 0 to 7 to be set by new additional editor sprites.

### DIFF
--- a/src/actchest.cpp
+++ b/src/actchest.cpp
@@ -79,7 +79,7 @@ void actChest(Entity *my) {
 
 		int chesttype = 0;
 
-		if (my->editorChestType >= 0) {
+		if (my->editorChestType >= 0) { //if chest spawned by editor sprite 75-82, manually set the chest content category.
 			chesttype = my->editorChestType;
 		}
 		else {

--- a/src/actchest.cpp
+++ b/src/actchest.cpp
@@ -78,10 +78,17 @@ void actChest(Entity *my) {
 		int itemcount = 0;
 
 		int chesttype = 0;
-		if( strcmp(map.name,"The Mystic Library") ) {
-			chesttype = rand()%8;
-		} else {
-			chesttype = 6; // magic chest
+
+		if (my->editorChestType >= 0) {
+			chesttype = my->editorChestType;
+		}
+		else {
+			if (strcmp(map.name, "The Mystic Library")) {
+				chesttype = rand() % 8;
+			}
+			else {
+				chesttype = 6; // magic chest
+			}
 		}
 
 		switch (chesttype) { //Note that all of this needs to be properly balanced over time.

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -113,6 +113,8 @@ Entity::Entity(Sint32 in_sprite, Uint32 pos, list_t *entlist) :
 	ranbehavior=FALSE;
 	parent = 0;
 	path = NULL;
+
+	editorChestType = -1;
 }
 
 /*-------------------------------------------------------------------------------

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -114,7 +114,7 @@ Entity::Entity(Sint32 in_sprite, Uint32 pos, list_t *entlist) :
 	parent = 0;
 	path = NULL;
 
-	editorChestType = -1;
+	editorChestType = -1; //initialize chest types to be random (<0)
 }
 
 /*-------------------------------------------------------------------------------

--- a/src/entity.hpp
+++ b/src/entity.hpp
@@ -67,6 +67,8 @@ public:
 	double scalex, scaley, scalez; // stretches/squashes the entity visually
 	Sint32 sizex, sizey;           // entity bounding box size
 	Sint32 sprite;                 // the entity's sprite index
+
+	int editorChestType;
 	
 	// network stuff
 	Uint32 lastupdate;                   // last time since the entity was updated

--- a/src/entity.hpp
+++ b/src/entity.hpp
@@ -68,7 +68,7 @@ public:
 	Sint32 sizex, sizey;           // entity bounding box size
 	Sint32 sprite;                 // the entity's sprite index
 
-	int editorChestType;
+	int editorChestType;		//field to be set if the chest sprite is 75-82 in the editor, otherwise should stay at value -1
 	
 	// network stuff
 	Uint32 lastupdate;                   // last time since the entity was updated

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -1803,7 +1803,8 @@ void assignActions(map_t *map) {
 				entity->yaw = PI/2;
 				entity->behavior = &actChest;
 				entity->sprite = 188;
-				
+				entity->editorChestType = -1;
+
 				childEntity = newEntity(216,0,map->entities);
 				childEntity->parent = entity->uid;
 				entity->parent = childEntity->uid;
@@ -2175,6 +2176,47 @@ void assignActions(map_t *map) {
 				entity->flags[PASSABLE] = TRUE;
 				entity->flags[NOUPDATE]=TRUE;
 				break;
+			case 75:
+			case 76:
+			case 77:
+			case 78:
+			case 79:
+			case 80:
+			case 81:
+			case 82:
+			{
+				entity->sizex = 3;
+				entity->sizey = 2;
+				entity->x += 8;
+				entity->y += 8;
+				entity->z = 5.5;
+				entity->yaw = PI / 2;
+				entity->behavior = &actChest;
+				entity->editorChestType = entity->sprite - 75; //MOD
+
+				entity->sprite = 188;
+
+				childEntity = newEntity(216, 0, map->entities);
+				childEntity->parent = entity->uid;
+				entity->parent = childEntity->uid;
+				childEntity->x = entity->x;
+				childEntity->y = entity->y - 3;
+				//printlog("29 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->uid,childEntity->x,childEntity->y);
+				childEntity->z = entity->z - 2.75;
+				childEntity->focalx = 3;
+				childEntity->focalz = -.75;
+				childEntity->yaw = PI / 2;
+				childEntity->sizex = 2;
+				childEntity->sizey = 2;
+				childEntity->behavior = &actChestLid;
+				childEntity->flags[PASSABLE] = TRUE;
+
+				//Chest inventory.
+				node_t *tempNode = list_AddNodeFirst(&entity->children);
+				tempNode->element = NULL;
+				tempNode->deconstructor = &emptyDeconstructor;
+				break;
+			}
 			default:
 				break;
 		}

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2192,7 +2192,7 @@ void assignActions(map_t *map) {
 				entity->z = 5.5;
 				entity->yaw = PI / 2;
 				entity->behavior = &actChest;
-				entity->editorChestType = entity->sprite - 75; //MOD
+				entity->editorChestType = entity->sprite - 75; //Set the chest content category from 0 to 7, depending on sprite index in editor.
 
 				entity->sprite = 188;
 


### PR DESCRIPTION
Added settable chest types through using editor sprites 75-82, so players can make maps with fixed reward categories and not use random chests. Random chests in map generation and the original editor icon still behave the same.

Sprites.txt (I don't think this file is in the repo?) needs to be modified to include 8 new lines for these icons, I just added 8 chests icons to the end:
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png

New to this Git thing, hopefully all changes are there.