### PR TITLE
Chest types 0 to 7 to be set by new additional editor sprites

### DIFF
--- a/src/actchest.cpp
+++ b/src/actchest.cpp
@@ -27,7 +27,7 @@
 #define CHEST_LIDCLICKED my->skill[6]
 #define CHEST_AMBIENCE my->skill[7]
 #define CHEST_MAXHEALTH my->skill[8]
-#define CHEST_TYPE my->skill[9] //field to be set if the chest sprite is 75-82 in the editor, otherwise should stay at value -1
+#define CHEST_TYPE my->skill[9] //field to be set if the chest sprite is 75-81 in the editor, otherwise should stay at value 0
 
 /*
  * Chest theme ideas:
@@ -87,7 +87,7 @@ void actChest(Entity* my)
 
 		int chesttype = 0;
 
-		if (CHEST_TYPE > 0) //If chest spawned by editor sprite 75-82, manually set the chest content category. Otherwise this value should be 0 (random).
+		if (CHEST_TYPE > 0) //If chest spawned by editor sprite 75-81, manually set the chest content category. Otherwise this value should be 0 (random).
 		{ 
 			chesttype = CHEST_TYPE; //Value between 1 and 7.
 		}

--- a/src/actchest.cpp
+++ b/src/actchest.cpp
@@ -27,6 +27,7 @@
 #define CHEST_LIDCLICKED my->skill[6]
 #define CHEST_AMBIENCE my->skill[7]
 #define CHEST_MAXHEALTH my->skill[8]
+#define CHEST_TYPE my->skill[9] //field to be set if the chest sprite is 75-82 in the editor, otherwise should stay at value -1
 
 /*
  * Chest theme ideas:
@@ -85,13 +86,21 @@ void actChest(Entity* my)
 		int itemcount = 0;
 
 		int chesttype = 0;
-		if ( strcmp(map.name, "The Mystic Library") )
-		{
-			chesttype = rand() % 8;
+
+		if (CHEST_TYPE > 0) //If chest spawned by editor sprite 75-82, manually set the chest content category. Otherwise this value should be 0 (random).
+		{ 
+			chesttype = CHEST_TYPE; //Value between 1 and 7.
 		}
-		else
+		else 
 		{
-			chesttype = 6; // magic chest
+			if (strcmp(map.name, "The Mystic Library")) 
+			{
+				chesttype = rand() % 8;
+			}
+			else 
+			{
+				chesttype = 6; // magic chest			
+			}
 		}
 
 		switch (chesttype)   //Note that all of this needs to be properly balanced over time.

--- a/src/actchest.cpp
+++ b/src/actchest.cpp
@@ -87,9 +87,9 @@ void actChest(Entity* my)
 
 		int chesttype = 0;
 
-		if (CHEST_TYPE > 0) //If chest spawned by editor sprite 75-81, manually set the chest content category. Otherwise this value should be 0 (random).
+		if (CHEST_TYPE >= 0) //If chest spawned by editor sprite 75-81, manually set the chest content category. Otherwise this value should be 0 (random).
 		{ 
-			chesttype = CHEST_TYPE; //Value between 1 and 7.
+			chesttype = CHEST_TYPE; //Value between 0 and 7.
 		}
 		else 
 		{

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2661,7 +2661,7 @@ void assignActions(map_t* map)
 				entity->y += 8;
 				entity->z = 5.5;
 				entity->yaw = PI / 2;
-				entity->skill[9] = entity->sprite - 75; //Set chest type to category value between 1 and 7 depending on case entity->sprite.
+				entity->skill[9] = entity->sprite - 75; //Set chest type to category value between 0 and 7 depending on case entity->sprite.
 				entity->behavior = &actChest;
 				entity->sprite = 188;
 

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2243,7 +2243,7 @@ void assignActions(map_t* map)
 				entity->yaw = PI / 2;
 				entity->behavior = &actChest;
 				entity->sprite = 188;
-				entity->skill[9] = 0; //Set default chest as random category.
+				entity->skill[9] = -1; //Set default chest as random category < 0
 
 				childEntity = newEntity(216, 0, map->entities);
 				childEntity->parent = entity->uid;
@@ -2653,6 +2653,7 @@ void assignActions(map_t* map)
 			case 79:
 			case 80:
 			case 81: 
+			case 82:
 			{
 				entity->sizex = 3;
 				entity->sizey = 2;
@@ -2660,7 +2661,7 @@ void assignActions(map_t* map)
 				entity->y += 8;
 				entity->z = 5.5;
 				entity->yaw = PI / 2;
-				entity->skill[9] = entity->sprite - 75 + 1; //Set chest type to category value between 1 and 7 depending on case entity->sprite.
+				entity->skill[9] = entity->sprite - 75; //Set chest type to category value between 1 and 7 depending on case entity->sprite.
 				entity->behavior = &actChest;
 				entity->sprite = 188;
 

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2243,7 +2243,7 @@ void assignActions(map_t* map)
 				entity->yaw = PI / 2;
 				entity->behavior = &actChest;
 				entity->sprite = 188;
-				entity->skill[9] = 0;
+				entity->skill[9] = 0; //Set default chest as random category.
 
 				childEntity = newEntity(216, 0, map->entities);
 				childEntity->parent = entity->uid;

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2243,6 +2243,7 @@ void assignActions(map_t* map)
 				entity->yaw = PI / 2;
 				entity->behavior = &actChest;
 				entity->sprite = 188;
+				entity->skill[9] = 0;
 
 				childEntity = newEntity(216, 0, map->entities);
 				childEntity->parent = entity->uid;
@@ -2644,6 +2645,46 @@ void assignActions(map_t* map)
 				entity->flags[PASSABLE] = TRUE;
 				entity->flags[NOUPDATE] = TRUE;
 				break;
+			//Chests with fixed content categories.
+			case 75: 
+			case 76:
+			case 77:
+			case 78:
+			case 79:
+			case 80:
+			case 81: 
+			{
+				entity->sizex = 3;
+				entity->sizey = 2;
+				entity->x += 8;
+				entity->y += 8;
+				entity->z = 5.5;
+				entity->yaw = PI / 2;
+				entity->skill[9] = entity->sprite - 75 + 1; //Set chest type to category value between 1 and 7 depending on case entity->sprite.
+				entity->behavior = &actChest;
+				entity->sprite = 188;
+
+				childEntity = newEntity(216, 0, map->entities);
+				childEntity->parent = entity->uid;
+				entity->parent = childEntity->uid;
+				childEntity->x = entity->x;
+				childEntity->y = entity->y - 3;
+				//printlog("29 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->uid,childEntity->x,childEntity->y);
+				childEntity->z = entity->z - 2.75;
+				childEntity->focalx = 3;
+				childEntity->focalz = -.75;
+				childEntity->yaw = PI / 2;
+				childEntity->sizex = 2;
+				childEntity->sizey = 2;
+				childEntity->behavior = &actChestLid;
+				childEntity->flags[PASSABLE] = TRUE;
+
+				//Chest inventory.
+				node_t* tempNode = list_AddNodeFirst(&entity->children);
+				tempNode->element = NULL;
+				tempNode->deconstructor = &emptyDeconstructor;
+				break;
+			}
 			default:
 				break;
 		}


### PR DESCRIPTION
Added settable chest types through using editor sprites 75-81, so players can make maps with fixed reward categories and not use random chests. Random chests in map generation and the original editor icon still behave the same.

Sprites.txt needs to be modified to include 7 new lines for these icons, I just added 7 chests icons to the end:
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png
images/sprites/chest.png

Updated to match latest master branch.