### PR TITLE
Fixed several monster naming, now can properly be set through editor.

### DIFF
--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -76,6 +76,8 @@ button_t* butItemOK;
 button_t* butItemCancel;
 button_t* butItemX;
 
+bool exitFromItemWindow = false;
+
 // Corner buttons
 
 void buttonExit(button_t* my)
@@ -1037,7 +1039,20 @@ void buttonSpriteProperties(button_t* my)
 			tmpSpriteStats = selectedEntity->getStats();
 			if ( tmpSpriteStats != nullptr )
 			{
-				copyMonsterStatToPropertyStrings(tmpSpriteStats);
+				if ( exitFromItemWindow == true )
+				{
+					exitFromItemWindow = false;
+					// retreives any modified monster stats, to be restored when window is closed.
+
+					for ( int i = 0; i < sizeof(spriteProperties) / sizeof(spriteProperties[0]); i++ )
+					{
+						strcpy(spriteProperties[i], tmpSpriteProperties[i]);
+					}
+				}
+				else
+				{
+					copyMonsterStatToPropertyStrings(tmpSpriteStats);
+				}
 				inputstr = spriteProperties[0];
 				initMonsterPropertiesWindow();
 			}
@@ -1702,6 +1717,13 @@ void buttonSpritePropertiesConfirm(button_t* my)
 						{
 							butMonsterItemCancel->visible = 0;
 						}
+
+						// retrieves any modified monster stats, restored when window is closed.
+
+						for ( int i = 0; i < sizeof(spriteProperties) / sizeof(spriteProperties[0]); i++ )
+						{
+							strcpy(spriteProperties[i], tmpSpriteProperties[i]);
+						}
 					}
 					else
 					{
@@ -1816,7 +1838,8 @@ void buttonSpritePropertiesConfirm(button_t* my)
 
 	if ( my == butMonsterItemOK && tmpSpriteStats != NULL )
 	{
-		copyMonsterStatToPropertyStrings(tmpSpriteStats);
+		//copyMonsterStatToPropertyStrings(tmpSpriteStats);
+		exitFromItemWindow = true;
 		inputstr = spriteProperties[0];
 		initMonsterPropertiesWindow();
 
@@ -1841,7 +1864,8 @@ void buttonCloseSpriteSubwindow(button_t* my)
 		}
 		if ( tmpSpriteStats != NULL )
 		{
-			copyMonsterStatToPropertyStrings(tmpSpriteStats);
+			//copyMonsterStatToPropertyStrings(tmpSpriteStats);
+			exitFromItemWindow = true;
 			inputstr = spriteProperties[0];
 			initMonsterPropertiesWindow();
 
@@ -1894,6 +1918,12 @@ void buttonMonsterItems(button_t* my)
 
 	Stat* tmpSpriteStats = selectedEntity->getStats();
 
+	// stores any modified monster stats, to be restored when window is closed.
+
+	for ( int i = 0; i < sizeof(spriteProperties) / sizeof(spriteProperties[0]); i++ )
+	{
+		strcpy(tmpSpriteProperties[i], spriteProperties[i]);
+	}
 
 	if ( my == butMonsterHelm )
 	{

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1455,10 +1455,11 @@ int main(int argc, char** argv)
 									// duplicate sprite
 									makeUndo();
 									selectedEntity = newEntity(entity->sprite, 0, map.entities);
+									lastSelectedEntity = entity;
 
 									Stat* tmpStats = lastSelectedEntity->getStats();
 
-									lastSelectedEntity = selectedEntity;
+									
 									int spriteType = checkSpriteType(selectedEntity->sprite);
 									if ( spriteType == 1 )
 									{

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -108,6 +108,7 @@ extern char message[48];
 extern Uint32 cursorflash;
 extern char widthtext[4], heighttext[4], nametext[32], authortext[32];
 extern char spriteProperties[32][128];
+extern char tmpSpriteProperties[32][128];
 extern int editproperty;
 extern bool mode3d;
 extern bool selectingspace;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,7 @@ char message[48];
 int messagetime = 0;
 char widthtext[4], heighttext[4], nametext[32], authortext[32];
 char spriteProperties[32][128];
+char tmpSpriteProperties[32][128];
 int editproperty = 0;
 SDL_Cursor* cursorArrow, *cursorPencil, *cursorBrush, *cursorSelect, *cursorFill;
 int* palette;

--- a/src/monster_automaton.cpp
+++ b/src/monster_automaton.cpp
@@ -42,7 +42,6 @@ void initAutomaton(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 40;

--- a/src/monster_cockatrice.cpp
+++ b/src/monster_cockatrice.cpp
@@ -42,7 +42,6 @@ void initCockatrice(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 80;

--- a/src/monster_crystalgolem.cpp
+++ b/src/monster_crystalgolem.cpp
@@ -108,7 +108,6 @@ void initCrystalgolem(Entity* my, Stat* myStats)
 
 		if ( rand() % 50 || my->flags[USERFLAG2] )
 		{
-			strcpy(myStats->name, "");
 		}
 		else
 		{

--- a/src/monster_demon.cpp
+++ b/src/monster_demon.cpp
@@ -57,7 +57,6 @@ void initDemon(Entity* my, Stat* myStats)
 			// boss variants
 			if ( rand() % 50 || my->flags[USERFLAG2] )
 			{
-				strcpy(myStats->name, "");
 			}
 			else
 			{

--- a/src/monster_ghoul.cpp
+++ b/src/monster_ghoul.cpp
@@ -56,7 +56,6 @@ void initGhoul(Entity* my, Stat* myStats)
 			// boss variants
 			if ( rand() % 50 || my->flags[USERFLAG2] )
 			{
-				strcpy(myStats->name, "");
 			}
 			else
 			{

--- a/src/monster_goatman.cpp
+++ b/src/monster_goatman.cpp
@@ -43,7 +43,6 @@ void initGoatman(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 60;

--- a/src/monster_goblin.cpp
+++ b/src/monster_goblin.cpp
@@ -57,7 +57,6 @@ void initGoblin(Entity* my, Stat* myStats)
 			// boss variants
 			if ( rand() % 50 || my->flags[USERFLAG2] )
 			{
-				strcpy(myStats->name, "");
 			}
 			else
 			{

--- a/src/monster_incubus.cpp
+++ b/src/monster_incubus.cpp
@@ -45,7 +45,6 @@ void initIncubus(Entity* my, Stat* myStats)
 		if ( rand() % 50 || my->flags[USERFLAG2] )
 		{
 			myStats->DEX = 3;
-			strcpy(myStats->name, "");
 		}
 		else
 		{

--- a/src/monster_insectoid.cpp
+++ b/src/monster_insectoid.cpp
@@ -43,7 +43,6 @@ void initInsectoid(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 60;

--- a/src/monster_kobold.cpp
+++ b/src/monster_kobold.cpp
@@ -43,7 +43,6 @@ void initKobold(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 50;

--- a/src/monster_scarab.cpp
+++ b/src/monster_scarab.cpp
@@ -41,7 +41,6 @@ void initScarab(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 30;

--- a/src/monster_shadow.cpp
+++ b/src/monster_shadow.cpp
@@ -43,7 +43,6 @@ void initShadow(Entity* my, Stat* myStats)
 	{
 		myStats->sex = static_cast<sex_t>(rand() % 2);
 		myStats->appearance = rand();
-		strcpy(myStats->name, "");
 		myStats->inventory.first = NULL;
 		myStats->inventory.last = NULL;
 		myStats->HP = 60;

--- a/src/monster_troll.cpp
+++ b/src/monster_troll.cpp
@@ -56,7 +56,6 @@ void initTroll(Entity* my, Stat* myStats)
 			// boss variants
 			if ( rand() % 50 || my->flags[USERFLAG2] )
 			{
-				strcpy(myStats->name, "");
 			}
 			else
 			{

--- a/src/stat_shared.cpp
+++ b/src/stat_shared.cpp
@@ -227,7 +227,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = SPIDER;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 50;
@@ -252,7 +251,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = GOBLIN;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 60;
@@ -365,7 +363,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = HUMAN;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand() % 18; //NUMAPPEARANCES = 18
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 30;
@@ -439,7 +436,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = VAMPIRE;
 			stats->sex = MALE;
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 30;
@@ -584,7 +580,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = CREATURE_IMP;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 80;
@@ -623,7 +618,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = MINOTAUR;
 			stats->sex = MALE;
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 400;
@@ -650,7 +644,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = SCORPION;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 70;
@@ -674,10 +667,9 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = SLIME;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
-			if ( stats->LVL == 7 )   // blue slime
+			if ( stats->LVL >= 7 )   // blue slime
 			{
 				stats->HP = 70;
 				stats->MAXHP = 70;
@@ -708,7 +700,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = SUCCUBUS;
 			stats->sex = FEMALE;
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->HP = 60;
 			stats->MAXHP = 60;
 			stats->MP = 40;
@@ -731,7 +722,6 @@ void setDefaultMonsterStats(Stat* stats, int sprite)
 			stats->type = RAT;
 			stats->sex = static_cast<sex_t>(rand() % 2);
 			stats->appearance = rand();
-			strcpy(stats->name, "");
 			stats->inventory.first = NULL;
 			stats->inventory.last = NULL;
 			stats->HP = 30;


### PR DESCRIPTION
Fixed crash when duplicating editor sprite after deleting the previous.

Stopped clearing of monster stats when you edit one of it's items. Now stats should properly remain until they are saved inside the main window.