### PR TITLE
Move inline item functions to header

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -2587,30 +2587,6 @@ node_t* getMeleeWeaponItemNodeInInventory(Stat* myStats)
 	return nullptr;
 }
 
-bool inline isRangedWeapon(const Item& item)
-{
-	switch ( item.type )
-	{
-		case SLING:
-		case SHORTBOW:
-		case CROSSBOW:
-		case ARTIFACT_BOW:
-			return true;
-		default:
-			return false;
-	}
-}
-
-bool inline isMeleeWeapon(const Item& item)
-{
-	if ( itemCategory(&item) != WEAPON )
-	{
-		return false;
-	}
-
-	return ( !isRangedWeapon(item) );
-}
-
 bool swapMonsterWeaponWithInventoryItem(Entity* my, Stat* myStats, node_t* inventoryNode)
 {
 	//TODO: Does this work with multiplayer?

--- a/src/items.hpp
+++ b/src/items.hpp
@@ -440,8 +440,20 @@ int itemCompare(const Item* item1, const Item* item2);
  * Returns true if potion is harmful to the player.
  */
 bool isPotionBad(const Item& potion);
-bool inline isRangedWeapon(const Item& item);
-bool inline isMeleeWeapon(const Item& item);
+bool inline isRangedWeapon(const Item& item)
+{
+	switch ( item.type )
+	{
+		case SLING:
+		case SHORTBOW:
+		case CROSSBOW:
+		case ARTIFACT_BOW:
+			return true;
+		default:
+			return false;
+	}
+}
+bool inline isMeleeWeapon(const Item& item) {return itemCategory(&item) == WEAPON && !isRangedWeapon(item);}
 
 void createCustomInventory(Stat* stats, int itemLimit);
 void copyItem(Item* itemToSet, Item* itemToCopy);


### PR DESCRIPTION
Since they are inlined, their implementation needs to be included in
every source file that uses them, otherwise it will go missing entirely
and fail to link.