### PR TITLE
[MASTER] Fix Issue #114 - Client fountains do not stop animating

### DIFF
--- a/src/actfountain.cpp
+++ b/src/actfountain.cpp
@@ -27,6 +27,12 @@
 	The following function describes an entity behavior. The function
 	takes a pointer to the entity that uses it as an argument.
 
+	my->skill[0] is either 0 or 1. If it is 0, the fountain is dry and cannot be used
+	my->skill[1] is either 0, 1, 2, or 3. It is set at the creation of the fountain.
+	Those values correspond to what the fountain does:
+	0 = spawn succubus, 1 = raise hunger, 2 = random potion effect, 3 = bless equipment
+	my->skill[3] is a random potion effect. It is set at the creation of the fountain
+
 -------------------------------------------------------------------------------*/
 
 void actFountain(Entity* my)
@@ -51,7 +57,7 @@ void actFountain(Entity* my)
 	//TODO: Sounds.
 
 	// spray water
-	if ( my->skill[0] > 0 || ( !my->skill[2] && multiplayer == CLIENT ) )
+	if ( my->skill[0] > 0 )
 	{
 #define FOUNTAIN_AMBIENCE my->skill[7]
 		FOUNTAIN_AMBIENCE--;
@@ -82,16 +88,6 @@ void actFountain(Entity* my)
 	if ( multiplayer == CLIENT )
 	{
 		return;
-	}
-
-	// makes the fountain stop spraying water on clients
-	if ( my->skill[0] <= 0 )
-	{
-		my->skill[2] = 1;
-	}
-	else
-	{
-		my->skill[2] = 0;
 	}
 
 	//Using the fountain (TODO: Monsters using it?).
@@ -208,6 +204,7 @@ void actFountain(Entity* my)
 					}
 					messagePlayer(i, language[474]);
 					my->skill[0] = 0; //Dry up fountain.
+					serverUpdateEntitySkill(my, my->skill[0]);
 					//TODO: messagePlayersInSight() instead.
 				}
 				//Then perform the effect randomly determined when the fountain was created.


### PR DESCRIPTION
This is a fix for Issue #114 for the master branch.
Clients were not being sync'd the changes to the fountain's status.
A simple call to 'serverUpdateEntitySkill()' solved that issue.

An optional change would be changing usage of 'my->skill[3]' to 'my->skill[2]' now that 'my->skill[2]' is unused.