### PR TITLE
[MASTER] Fix Issue #102 - Host "On Fire" status does not disappear

### DIFF
--- a/src/actfountain.cpp
+++ b/src/actfountain.cpp
@@ -114,10 +114,7 @@ void actFountain(Entity* my)
 					{
 						messagePlayer(i, language[468]);
 						players[i]->entity->flags[BURNING] = false;
-						if (i > 0)
-						{
-							serverUpdateEntityFlag(players[i]->entity, BURNING);
-						}
+						serverUpdateEntityFlag(players[i]->entity, BURNING);
 					}
 					switch (my->skill[1])
 					{

--- a/src/actplayer.cpp
+++ b/src/actplayer.cpp
@@ -932,10 +932,7 @@ void actPlayer(Entity* my)
 						{
 							my->flags[BURNING] = false;
 							messagePlayer(PLAYER_NUM, language[574]);
-							if ( PLAYER_NUM > 0 )
-							{
-								serverUpdateEntityFlag(my, BURNING);
-							}
+							serverUpdateEntityFlag(my, BURNING);
 						}
 					}
 					else if ( ticks % 10 == 0 )

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1956,10 +1956,7 @@ void Entity::handleEffects(Stat* myStats)
 			{
 				this->flags[BURNING] = false;
 				messagePlayer(player, language[647]);
-				if ( player > 0 && multiplayer == SERVER )
-				{
-					serverUpdateEntityFlag(this, BURNING);
-				}
+				serverUpdateEntityFlag(this, BURNING);
 			}
 		}
 	}


### PR DESCRIPTION
This is a fix for #102.
The issue is caused by if statement checks that say if the player is a Client, update your status. These checks prevented the actual logic from running for the Host's entity on the Client.