### PR TITLE
[MASTER] Fix Issue #125 - Spell of Opening does not unlock doors

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -1799,74 +1799,93 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						return;
 					}
 				}
-				else if (!strcmp(element->name, spellElement_opening.name))
+				else if ( !strcmp(element->name, spellElement_opening.name) )
 				{
-					if (hit.entity)
+					if ( hit.entity )
 					{
-						if (hit.entity->behavior == &actDoor)
+						if ( hit.entity->behavior == &actDoor )
 						{
-							//Open door
-							if (!hit.entity->skill[0] && !hit.entity->skill[3])
+							// Unlock the Door
+							playSoundEntity(hit.entity, 91, 64); // "UnlockDoor.ogg"
+							hit.entity->skill[5] = 0; // Unlocks the Door
+
+							// Open the Door
+							if ( !hit.entity->skill[0] && !hit.entity->skill[3] )
 							{
 								hit.entity->skill[3] = 1 + (my->x > hit.entity->x);
-								playSoundEntity(hit.entity, 21, 96);
+								playSoundEntity(hit.entity, 21, 96); // "DoorOpen1V2wav.ogg"
 							}
-							else if (hit.entity->skill[0] && !hit.entity->skill[3])
+							else if ( hit.entity->skill[0] && !hit.entity->skill[3] )
 							{
 								hit.entity->skill[3] = 1 + (my->x < hit.entity->x);
-								playSoundEntity(hit.entity, 21, 96);
+								playSoundEntity(hit.entity, 21, 96); // "DoorOpen1V2wav.ogg"
 							}
+
 							if ( parent )
-								if ( parent->behavior == &actPlayer)
+							{
+								if ( parent->behavior == &actPlayer )
 								{
-									messagePlayer(parent->skill[2], language[402]);
+									messagePlayer(parent->skill[2], language[402]); // "You open the door!"
 								}
+							}
 						}
-						else if (hit.entity->behavior == &actGate)
+						else if ( hit.entity->behavior == &actGate )
 						{
-							//Open gate
+							// Open the Gate
 							if ( hit.entity->skill[28] != 2 )
 							{
-								hit.entity->skill[28] = 2; // power it
+								hit.entity->skill[28] = 2; // Powers the Gate
+
 								if ( parent )
-									if ( parent->behavior == &actPlayer)
+								{
+									if ( parent->behavior == &actPlayer )
 									{
-										messagePlayer(parent->skill[2], language[403]);
+										messagePlayer(parent->skill[2], language[403]); // "The spell opens the gate!"
 									}
+								}
 							}
 						}
-						else if (hit.entity->behavior == &actChest)
+						else if ( hit.entity->behavior == &actChest )
 						{
-							//Unlock chest
+							// Unlock the Chest
 							if ( hit.entity->skill[4] )
 							{
-								playSoundEntity(hit.entity, 91, 64);
-								hit.entity->skill[4] = 0;
+								playSoundEntity(hit.entity, 91, 64); // "UnlockDoor.ogg"
+								hit.entity->skill[4] = 0; // Unlocks the Chest
+
 								if ( parent )
-									if ( parent->behavior == &actPlayer)
+								{
+									if ( parent->behavior == &actPlayer )
 									{
-										messagePlayer(parent->skill[2], language[404]);
+										messagePlayer(parent->skill[2], language[404]); // "The spell unlocks the chest!"
 									}
+								}
 							}
 						}
 						else
 						{
 							if ( parent )
+							{
 								if ( parent->behavior == &actPlayer )
 								{
-									messagePlayer(parent->skill[2], language[401]);
+									messagePlayer(parent->skill[2], language[401]); // "No telling what it did..."
 								}
+							}
+
 							if ( player >= 0 )
 							{
-								messagePlayer(player, language[401]);
+								messagePlayer(player, language[401]); // "No telling what it did..."
 							}
 						}
+
 						spawnMagicEffectParticles(hit.entity->x, hit.entity->y, hit.entity->z, my->sprite);
-						if (my->light != NULL)
+
+						if ( my->light != nullptr )
 						{
 							list_RemoveNode(my->light->node);
-							my->light = NULL;
+							my->light = nullptr;
 						}
+
 						list_RemoveNode(my->mynode);
 						return;
 					}


### PR DESCRIPTION
This is a fix for #125.
The issue was there was no change to the actual lock status of the door being hit, the Spell of Opening would simply do as it's name implies and "open" the door. This however, puts the door in a intangible state, as it is no longer a physical Entity.