### PR TITLE
[MASTER] Fix Issue #115 - Handle Client Disconnect Gracefully

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2710,7 +2710,7 @@ void serverHandlePacket()
 		{
 			if ( client_disconnected[c] == true )
 			{
-				return;
+				continue;
 			}
 			strncpy((char*)net_packet->data, "DISCONNECT", 10);
 			net_packet->data[10] = playerDisconnected;


### PR DESCRIPTION
This is a fix for #115.
The issue was there was a `return` where there should have been a `continue`. This was causing disconnections to not get processed on any remaining Clients. It also prevented the Host from ever being notified that a Client disconnected.