### PR TITLE
[MASTER] Fix Issue #100 - Client cannot see themselves "On Fire"

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -1207,6 +1207,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							if ( !hit.entity->flags[BURNING] )
 							{
 								hit.entity->flags[BURNING] = true;
+								serverUpdateEntityFlag(hit.entity, BURNING);
 							}
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{


### PR DESCRIPTION
This is a fix for #100.
The issue was caused by issues similar and related to #102 and #119. Adding a call to 'serverUpdateEntityFlag()' is all that was missing in this case. Every case of a Client being set on fire works.