### PR TITLE
[MASTER] Fix Issue #116 - Head Bobbing when typing

### DIFF
--- a/src/actplayer.cpp
+++ b/src/actplayer.cpp
@@ -979,7 +979,7 @@ void actPlayer(Entity* my)
 					PLAYER_BOBMOVE -= .03;
 				}
 			}
-			if ( (*inputPressed(impulses[IN_FORWARD]) || *inputPressed(impulses[IN_BACK])) || (*inputPressed(impulses[IN_RIGHT]) - *inputPressed(impulses[IN_LEFT])) || (game_controller && (game_controller->getLeftXPercent() || game_controller->getLeftYPercent())) && !command && !swimming)
+			if ( ((*inputPressed(impulses[IN_FORWARD]) || *inputPressed(impulses[IN_BACK])) || (*inputPressed(impulses[IN_RIGHT]) - *inputPressed(impulses[IN_LEFT])) || (game_controller && (game_controller->getLeftXPercent() || game_controller->getLeftYPercent()))) && !command && !swimming)
 			{
 				if (!stats[clientnum]->defending)
 				{


### PR DESCRIPTION
This is a fix for #116.
This issue was fixed by correcting the parentheses on a check to prevent keyboard input (WASD) from causing head bobbing effects.