### PR TITLE
[MASTER] Fix Issue #120 - Cure Ailment does not remove Fire on Clients

### DIFF
--- a/src/magic/castSpell.cpp
+++ b/src/magic/castSpell.cpp
@@ -644,7 +644,7 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 					}
 					if ( players[clientnum]->entity->flags[BURNING] )
 					{
-						players[clientnum]->entity->flags[BURNING] = false;
+						players[i]->entity->flags[BURNING] = false;
 						serverUpdateEntityFlag(players[clientnum]->entity, BURNING);
 					}
 					serverUpdateEffects(player);


### PR DESCRIPTION
This is a fix for #120 and #42.
The issue was the spell of Cure Ailment was checking only the local player (host), for the burning flag. This was fixed to check for the player that is actually casting the spell.