### PR TITLE
[MASTER] Fix Issue #126 - Client is not affected by Slow Spell

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -1433,6 +1433,13 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							hitstats->EFFECTS[EFF_SLOW] = true;
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] = (element->duration * (((element->mana) / element->base_mana) * element->overload_multiplier));
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] /= (1 + (int)resistance);
+
+							// If the Entity hit is a Player (Client), update them to be Slowed
+							if ( hit.entity->behavior == &actPlayer )
+							{
+								serverUpdateEffects(hit.entity->skill[2]);
+							}
+
 							int damage = element->damage;
 							//damage += ((element->mana - element->base_mana) / element->overload_multiplier) * element->damage;
 							damage *= damagetables[hitstats->type][5];
@@ -1506,6 +1513,13 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							hitstats->EFFECTS[EFF_SLOW] = true;
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] = (element->duration * (((element->mana) / element->base_mana) * element->overload_multiplier));
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] /= (1 + (int)resistance);
+
+							// If the Entity hit is a Player (Client), update them to be Slowed
+							if ( hit.entity->behavior == &actPlayer )
+							{
+								serverUpdateEffects(hit.entity->skill[2]);
+							}
+
 							// update enemy bar for attacker
 							if ( parent )
 							{


### PR DESCRIPTION
This is a fix for #126.
The issue was that the Client was not being synced the fact that their status effects had been changed. Appropriate calls were added to fix that, to both the Slow spell, and the Cold spell, which applies the Slow effect.