### PR TITLE
[MASTER] Fix Issue #127 - Client is not affected by Confuse Spell

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -1376,6 +1376,13 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							hitstats->EFFECTS[EFF_CONFUSED] = true;
 							hitstats->EFFECTS_TIMERS[EFF_CONFUSED] = (element->duration * (((element->mana) / element->base_mana) * element->overload_multiplier));
 							hitstats->EFFECTS_TIMERS[EFF_CONFUSED] /= (1 + (int)resistance);
+
+							// If the Entity hit is a Player (Client) then update their status effects to be Confused
+							if ( hit.entity->behavior == &actPlayer )
+							{
+								serverUpdateEffects(hit.entity->skill[2]);
+							}
+
 							hit.entity->skill[1] = 0; //Remove the monster's target.
 							if ( parent )
 							{


### PR DESCRIPTION
This is a fix for #127.
The issue was that the Client was not being synced the fact that their status effects had been changed. The appropriate call was added to the Confuse spell to fix that.