### PR TITLE
[MASTER] Fix Issue #130 - Notify Player when they are no longer Slowed

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -653,6 +653,9 @@ void Entity::effectTimes()
 					case EFF_BLEEDING:
 						messagePlayer(player, language[614]);
 						break;
+					case EFF_SLOW:
+						messagePlayer(player, language[604]); // "You return to your normal speed."
+						break;
 					default:
 						break;
 				}


### PR DESCRIPTION
This is a fix for #130.
The issue was there was a missing case statement for EFF_SLOW which meant nothing would be done once the Player was no longer slowed. Adding a case that displays the same message as EFF_FAST "You return to your normal speed." is a good fix.