### PR TITLE
[MASTER] Fix Issue #129 - Entities can cast spells while Asleep

### DIFF
--- a/VS-includes/Config.hpp
+++ b/VS-includes/Config.hpp
@@ -1,6 +1,6 @@
 
 #define WINDOWS
 
-//#define STEAMWORKS
+#define STEAMWORKS
 
 #define HAVE_FMOD

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 // REMEMBER TO CHANGE THIS WITH EVERY NEW OFFICIAL VERSION!!!
-#define VERSION "v2.0.5"
+#define VERSION "v2.0.6"
 #define GAME_CODE
 
 #define MAX_FPS_LIMIT 60 //TODO: Make this configurable.

--- a/src/magic/castSpell.cpp
+++ b/src/magic/castSpell.cpp
@@ -110,7 +110,8 @@ void castSpellInit(Uint32 caster_uid, spell_t* spell)
 		return;
 	}
 
-	if (stat->EFFECTS[EFF_PARALYZED])
+	// Entity cannot cast spells while paralyzed or asleep
+	if ( stat->EFFECTS[EFF_PARALYZED] || stat->EFFECTS[EFF_ASLEEP] )
 	{
 		return;
 	}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -3912,6 +3912,7 @@ void handleMainMenu(bool mode)
 				{
 					stats[clientnum]->clearStats();
 					initClass(clientnum);
+					mapseed = 0;
 				}
 				else
 				{
@@ -3931,7 +3932,6 @@ void handleMainMenu(bool mode)
 				}
 #endif
 				// load next level
-				mapseed = 0;
 				entity_uids = 1;
 				lastEntityUIDs = entity_uids;
 				numplayers = 0;


### PR DESCRIPTION
This is a fix for #129.
The issue was there was a missing check in 'castSpellInit()' for seeing if the Entity was Asleep. There was already one for being Paralyzed, but not one for `EFF_ASLEEP`.