### PR TITLE
[MASTER] Fix Issue #219 - Poison Kills Buddha

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1788,17 +1788,28 @@ void Entity::handleEffects(Stat* myStats)
 		{
 			this->char_poison = 0;
 			int poisonhurt = std::max(1 + rand() % 4 - myStats->CON, 3);
-			this->modHP(-poisonhurt);
-			if ( myStats->HP <= 0 )
+
+			if ( buddhamode )
 			{
-				Entity* killer = uidToEntity( myStats->poisonKiller );
-				if ( killer )
+				if ( myStats->HP - poisonhurt > 0 )
 				{
-					killer->awardXP( this, true, true );
+					this->modHP(-poisonhurt);
+
+					if ( myStats->HP <= 0 )
+					{
+						Entity* killer = uidToEntity(myStats->poisonKiller);
+						if ( killer )
+						{
+							killer->awardXP(this, true, true);
+						}
+					}
+
+					this->setObituary(language[1531]);
 				}
 			}
-			this->setObituary(language[1531]);
+
 			playSoundEntity(this, 28, 64);
+
 			if ( player == clientnum )
 			{
 				camera_shakex += .1;
@@ -1814,6 +1825,7 @@ void Entity::handleEffects(Stat* myStats)
 				net_packet->len = 6;
 				sendPacketSafe(net_sock, -1, net_packet, player - 1);
 			}
+
 			if ( rand() % 5 == 0 )
 			{
 				messagePlayer(player, language[641]);

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1812,6 +1812,21 @@ void Entity::handleEffects(Stat* myStats)
 					this->setHP(1);
 				}
 			}
+			else
+			{
+				this->modHP(-poisonhurt);
+
+				if ( myStats->HP <= 0 )
+				{
+					Entity* killer = uidToEntity(myStats->poisonKiller);
+					if ( killer )
+					{
+						killer->awardXP(this, true, true);
+					}
+				}
+
+				this->setObituary(language[1531]);
+			}
 
 			playSoundEntity(this, 28, 64);
 

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1806,6 +1806,11 @@ void Entity::handleEffects(Stat* myStats)
 
 					this->setObituary(language[1531]);
 				}
+				else
+				{
+					// Instead of killing the Buddha Player, set their HP to 1
+					this->setHP(1);
+				}
 			}
 
 			playSoundEntity(this, 28, 64);


### PR DESCRIPTION
This is a fix for #219.
The issue is that `modHP()` does not do any checks for `godmode` or `buddhamode`. Adding a check there would be bad as `buddhamode` normally leaves you with 1 HP at the least. Changing modHP will affect every source of HP modifications, and that is why the check is made in `handleEffects()`.