### PR TITLE
[MASTER] Fix Issues #220 - Hungry Buddha Dies

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1582,6 +1582,17 @@ void Entity::handleEffects(Stat* myStats)
 							this->setHP(1);
 						}
 					}
+					else
+					{
+						this->modHP(-4);
+
+						if ( myStats->HP > 0 )
+						{
+							messagePlayer(player, language[633]);
+						}
+
+						this->setObituary(language[1530]);
+					}
 				}
 			}
 		}

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1563,13 +1563,21 @@ void Entity::handleEffects(Stat* myStats)
 				serverUpdateHunger(player);
 				if ( player >= 0 )   // bad guys don't starve. Sorry.
 				{
-					this->modHP(-4);
+					if ( buddhamode )
+					{
+						if ( myStats->HP - 4 > 0 )
+						{
+							this->modHP(-4);
+
+							if ( myStats->HP > 0 )
+							{
+								messagePlayer(player, language[633]);
+							}
+
+							this->setObituary(language[1530]);
+						}
+					}
 				}
-				if ( myStats->HP > 0 )
-				{
-					messagePlayer(player, language[633]);
-				}
-				this->setObituary(language[1530]);
 			}
 		}
 	}

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1576,6 +1576,11 @@ void Entity::handleEffects(Stat* myStats)
 
 							this->setObituary(language[1530]);
 						}
+						else
+						{
+							// Instead of killing the Buddha Player, set their HP to 1
+							this->setHP(1);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is a fix for #220.
The issue is that `modHP()` does not do any checks for `godmode` or `buddhamode`. Adding a check there would be bad as `buddhamode` normally leaves you with 1 HP at the least. Changing modHP will affect every source of HP modifications, and that is why the check is made in `handleEffects()`.

Additionally, I believe it would be beneficial for taking damage from hunger to cause a screen shake and a damage noise. I can add that to this PR, or to a separate one.