### PR TITLE
[MASTER] Fix Issue #73 - Shopkeeper Hostility does not consistently trigger

### DIFF
--- a/src/actmonster.cpp
+++ b/src/actmonster.cpp
@@ -1683,6 +1683,29 @@ void actMonster(Entity* my)
 			}
 		}
 
+		// Check if Shopkeepers are now hostile against Players
+		if ( myStats->type == SHOPKEEPER )
+		{
+			Entity* targetedEntity = uidToEntity(MONSTER_TARGET);
+
+			if ( targetedEntity != nullptr )
+			{
+				// Shopkeepers hold a grudge against players
+				for ( Uint8 iPlayerIndex = 0; iPlayerIndex < MAXPLAYERS; iPlayerIndex++ )
+				{
+					if ( players[iPlayerIndex] && players[iPlayerIndex]->entity )
+					{
+						if ( MONSTER_TARGET == players[iPlayerIndex]->entity->getUID() )
+						{
+							swornenemies[SHOPKEEPER][HUMAN] = true;
+							monsterally[SHOPKEEPER][HUMAN] = false;
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		// state machine
 		if ( MONSTER_STATE == 0 )   // wait state
 		{
@@ -2161,23 +2184,6 @@ void actMonster(Entity* my)
 			MONSTER_TARGETX = entity->x;
 			MONSTER_TARGETY = entity->y;
 			hitstats = entity->getStats();
-
-			if (myStats->type == SHOPKEEPER)
-			{
-				// shopkeepers hold a grudge against players
-				for (c = 0; c < MAXPLAYERS; c++)
-				{
-					if (players[c] && players[c]->entity)
-					{
-						if (MONSTER_TARGET == players[c]->entity->getUID())
-						{
-							swornenemies[SHOPKEEPER][HUMAN] = true;
-							monsterally[SHOPKEEPER][HUMAN] = false;
-							break;
-						}
-					}
-				}
-			}
 
 			if ( myStats->type != DEVIL )
 			{


### PR DESCRIPTION
This is a fix for #73.
The issue is that the code that triggers Shopkeeper's hostility towards Players is only performed in the "Charge" state. If a Player attacks a stationary Shopkeeper from up close, the Shopkeeper will move towards the Player, but will not trigger any aggression. However, if a Player is slightly further away, the Shopkeeper will move towards the Player, allowing the code to trigger, setting Player's as `swornenemies[SHOPKEEPER][HUMAN]`.

This is fixed by extracting the code out of the state machine. This allows for hostility to be triggered during any state. This does not fix the exact same issue for Humans (potential Followers and the like), which will be addressed in a separate PR.