### PR TITLE
Fix Issue #221 - Hit by Slingshot gives wrong message

### DIFF
--- a/VS.2015/Barony/Barony.vcxproj.filters
+++ b/VS.2015/Barony/Barony.vcxproj.filters
@@ -249,65 +249,8 @@
     <ClCompile Include="..\..\src\player.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\monster_automaton.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_cockatrice.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_crystalgolem.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_goatman.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_incubus.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_insectoid.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_lichfire.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_lichice.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_scarab.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_shadow.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_vampire.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\magic\act_HandMagic.cpp">
       <Filter>Source Files\magic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_kobold.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\actpowercrystal.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\actsummontrap.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\cursors.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\entity_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\item_tool.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\monster_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stat_shared.cpp">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\bookgui.cpp">
       <Filter>Source Files\interface</Filter>
@@ -318,13 +261,7 @@
     <ClCompile Include="..\..\src\interface\consolecommand.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\interface\drawminimap.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\interface\drawstatus.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\interface\identify_and_appraise.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\interface.cpp">
@@ -334,9 +271,6 @@
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\playerinventory.cpp">
-      <Filter>Source Files\interface</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\interface\removecurse.cpp">
       <Filter>Source Files\interface</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\interface\screenshot.cpp">
@@ -368,6 +302,69 @@
     </ClCompile>
     <ClCompile Include="..\..\src\magic\spell.cpp">
       <Filter>Source Files\magic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\identify_and_appraise.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\removecurse.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\interface\drawminimap.cpp">
+      <Filter>Source Files\interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\actpowercrystal.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\entity_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\item_tool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_automaton.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_cockatrice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_crystalgolem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_goatman.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_incubus.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_insectoid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_kobold.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_lichfire.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_lichice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_scarab.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_shadow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\monster_vampire.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\stat_shared.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\actsummontrap.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -443,26 +440,14 @@
     <ClInclude Include="..\..\src\player.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\collision.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\colors.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\cppfuncs.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\hash.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\paths.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\interface\interface.hpp">
       <Filter>Header Files\interface</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\magic\magic.hpp">
       <Filter>Header Files\magic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\collision.hpp">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/VS.2015/editor/editor.vcxproj.filters
+++ b/VS.2015/editor/editor.vcxproj.filters
@@ -80,16 +80,10 @@
     <ClCompile Include="..\..\src\entity_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\entity_shared.cpp">
+    <ClCompile Include="..\..\src\items_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\stat_editor.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stat_shared.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\items_editor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/lang/en.txt
+++ b/lang/en.txt
@@ -2979,5 +2979,6 @@ dominate the %s into your service!#
 2476 You feel the reflect magic spell fail as the
 last of your magic is drained!#
 
+2499 You are hit by a stone!#
 
-2499 end#
+2500 end#

--- a/src/actarrow.cpp
+++ b/src/actarrow.cpp
@@ -276,7 +276,22 @@ void actArrow(Entity* my)
 					else if ( hit.entity->behavior == &actPlayer )
 					{
 						Uint32 color = SDL_MapRGB(mainsurface->format, 255, 0, 0);
-						messagePlayerColor(hit.entity->skill[2], color, language[451]);
+
+						// Display a message telling the Player what they were hit by
+						switch ( my->sprite )
+						{
+							case 78: // "Rock.vox"
+								messagePlayerColor(hit.entity->skill[2], color, language[2499]); // "You are hit by a stone!"
+								break;
+							case 166: // "Arrow.vox"
+								// Intentional Fall-through TODOR: Should there be a separate message for bolts and arrows?
+							case 167: // "Bolt.vox"
+								messagePlayerColor(hit.entity->skill[2], color, language[451]); // "You are hit by an arrow!"
+								break;
+							default:
+								printlog("WARNING: actArrow() - 'You are hit by X' message not implemented for Model #%d", my->sprite); break;
+						}
+
 						if ( damage == 0 )
 						{
 							messagePlayer(hit.entity->skill[2], language[452]);

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -450,7 +450,7 @@ extern int minotaurlevel;
 #define DIRECTCLIENT 4
 
 // language stuff
-#define NUMLANGENTRIES 2500
+#define NUMLANGENTRIES 2501
 extern char languageCode[32];
 extern char** language;
 


### PR DESCRIPTION
This is a fix for #221.
The issue is that there is no separate lang entry for being hit by a stone. Additionally, in `actArrow()` there is no separate usage, since there is no entry. I added an entry, and a usage that can be scaled to accommodate more types of projectiles.