### PR TITLE
Fix Issue #244 - Client does not respawn with half MP

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1700,7 +1700,8 @@ void clientHandlePacket()
 		else if ( !strcmp((char*)(&net_packet->data[8]), language[1109]) )
 		{
 			// ... or lived
-			stats[clientnum]->HP = stats[clientnum]->MAXHP / 2;
+			stats[clientnum]->HP = stats[clientnum]->MAXHP * 0.5;
+			stats[clientnum]->MP = stats[clientnum]->MAXMP * 0.5;
 			stats[clientnum]->HUNGER = 500;
 			for ( c = 0; c < NUMEFFECTS; c++ )
 			{


### PR DESCRIPTION
This is a fix for #244.
The issue is that there was just a missing line of code to match the Host's code of setting the Client's MP to be 1/2 that of their max.