### PR TITLE
Fix Issue #249 - Fireball can set friendlies on fire with F.F. off

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -1090,12 +1090,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					spawnExplosion(my->x, my->y, my->z);
 					if (hit.entity)
 					{
-						if ( hit.entity->flags[BURNABLE] )
-							if ( !hit.entity->flags[BURNING] )
-							{
-								hit.entity->flags[BURNING] = true;
-								serverUpdateEntityFlag(hit.entity, BURNING);
-							}
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
 							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
@@ -1220,6 +1214,16 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							my->removeLightField();
 							list_RemoveNode(my->mynode);
 							return;
+						}
+
+						// Set the Entity on Fire, if the Entity is a friendly, and Friendly Fire is Off, then this will not be reached
+						if ( hit.entity->flags[BURNABLE] )
+						{
+							if ( !hit.entity->flags[BURNING] )
+							{
+								hit.entity->flags[BURNING] = true;
+								serverUpdateEntityFlag(hit.entity, BURNING);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This is a fix for #249.
The issue is that the Entity is set on fire before checking to see what Entity is. This prevents the check for friendly fire from happening before the Entity. I placed the code that sets the Entity on fire at the end, which will prevent the spell from setting friendly Players or Monsters (Humans/Shopkeepers) on fire.