### PR TITLE
Fix Issue #251 - Spells aggro friendlies with F.F. off and other fixes

### DIFF
--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -523,56 +523,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					}
 				}
 
-				if (hit.entity)
-				{
-					// alert the hit entity if it was a monster
-					if ( hit.entity->behavior == &actMonster && parent != nullptr )
-					{
-						if ( hit.entity->monsterState != MONSTER_STATE_ATTACK && (hitstats->type < LICH || hitstats->type >= SHOPKEEPER) )
-						{
-							/*hit.entity->monsterState = MONSTER_STATE_PATH;
-							hit.entity->monsterTarget = parent->getUID();
-							hit.entity->monsterTargetX = parent->x;
-							hit.entity->monsterTargetY = parent->y;*/
-
-							hit.entity->monsterAcquireAttackTarget(*parent, MONSTER_STATE_PATH);
-						}
-
-						// alert other monsters too
-						Entity* ohitentity = hit.entity;
-						for ( node = map.entities->first; node != nullptr; node = node->next )
-						{
-							entity = (Entity*)node->element;
-							if ( entity->behavior == &actMonster && entity != ohitentity )
-							{
-								Stat* buddystats = entity->getStats();
-								if ( buddystats != nullptr )
-								{
-									if ( hit.entity && hit.entity->checkFriend(entity) ) //TODO: hit.entity->checkFriend() without first checking if it's NULL crashes because hit.entity turns to NULL somewhere along the line. It looks like ohitentity preserves that value though, so....uh...ya, I don't know.
-									{
-										if ( entity->monsterState == MONSTER_STATE_WAIT )
-										{
-											tangent = atan2( entity->y - ohitentity->y, entity->x - ohitentity->x );
-											lineTrace(ohitentity, ohitentity->x, ohitentity->y, tangent, 1024, 0, false);
-											if ( hit.entity == entity )
-											{
-												/*entity->monsterState = MONSTER_STATE_PATH;
-												entity->monsterTarget = parent->getUID();
-												entity->monsterTargetX = parent->x;
-												entity->monsterTargetY = parent->y;*/
-
-												entity->monsterAcquireAttackTarget(*parent, MONSTER_STATE_PATH);
-											}
-										}
-									}
-								}
-							}
-						}
-						hit.entity = ohitentity;
-					}
-				}
-
-				// check for magic reflection...
+				// Handling reflecting the missile
 				int reflection = 0;
 				if ( hitstats )
 				{
@@ -610,7 +561,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 				{
 					spell_t* spellIsReflectingMagic = hit.entity->getActiveMagicEffect(SPELL_REFLECT_MAGIC);
 					playSoundEntity(hit.entity, 166, 128);
-					if (hit.entity)
+					if ( hit.entity )
 					{
 						if ( hit.entity->behavior == &actPlayer )
 						{
@@ -639,7 +590,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						my->vel_y *= -1;
 					}
-					if (hit.entity)
+					if ( hit.entity )
 					{
 						if ( parent && parent->behavior == &actMagicTrapCeiling )
 						{
@@ -655,7 +606,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						}
 						my->parent = hit.entity->getUID();
 					}
-					
+
 					// Only degrade the equipment if Friendly Fire is ON or if it is (OFF && target is an enemy)
 					bool bShouldEquipmentDegrade = false;
 					if ( (svFlags & SV_FLAG_FRIENDLYFIRE) )
@@ -769,7 +720,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							}
 						}
 					}
-					
+
 					if ( spellIsReflectingMagic )
 					{
 						int spellCost = getCostOfSpell(spell);
@@ -804,6 +755,56 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						my->removeLightField();
 						list_RemoveNode(my->mynode);
 						return;
+					}
+				}
+
+				// Alerting the hit Entity
+				if (hit.entity)
+				{
+					// alert the hit entity if it was a monster
+					if ( hit.entity->behavior == &actMonster && parent != nullptr )
+					{
+						if ( hit.entity->monsterState != MONSTER_STATE_ATTACK && (hitstats->type < LICH || hitstats->type >= SHOPKEEPER) )
+						{
+							/*hit.entity->monsterState = MONSTER_STATE_PATH;
+							hit.entity->monsterTarget = parent->getUID();
+							hit.entity->monsterTargetX = parent->x;
+							hit.entity->monsterTargetY = parent->y;*/
+
+							hit.entity->monsterAcquireAttackTarget(*parent, MONSTER_STATE_PATH);
+						}
+
+						// alert other monsters too
+						Entity* ohitentity = hit.entity;
+						for ( node = map.entities->first; node != nullptr; node = node->next )
+						{
+							entity = (Entity*)node->element;
+							if ( entity->behavior == &actMonster && entity != ohitentity )
+							{
+								Stat* buddystats = entity->getStats();
+								if ( buddystats != nullptr )
+								{
+									if ( hit.entity && hit.entity->checkFriend(entity) ) //TODO: hit.entity->checkFriend() without first checking if it's NULL crashes because hit.entity turns to NULL somewhere along the line. It looks like ohitentity preserves that value though, so....uh...ya, I don't know.
+									{
+										if ( entity->monsterState == MONSTER_STATE_WAIT )
+										{
+											tangent = atan2( entity->y - ohitentity->y, entity->x - ohitentity->x );
+											lineTrace(ohitentity, ohitentity->x, ohitentity->y, tangent, 1024, 0, false);
+											if ( hit.entity == entity )
+											{
+												/*entity->monsterState = MONSTER_STATE_PATH;
+												entity->monsterTarget = parent->getUID();
+												entity->monsterTargetX = parent->x;
+												entity->monsterTargetY = parent->y;*/
+
+												entity->monsterAcquireAttackTarget(*parent, MONSTER_STATE_PATH);
+											}
+										}
+									}
+								}
+							}
+						}
+						hit.entity = ohitentity;
 					}
 				}
 

--- a/src/magic/actmagic.cpp
+++ b/src/magic/actmagic.cpp
@@ -656,7 +656,7 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						my->parent = hit.entity->getUID();
 					}
 					
-					// Test for Friendly Fire, if Friendly Fire is OFF, delete the missile
+					// Only degrade the equipment if Friendly Fire is ON or if it is (OFF && target is an enemy)
 					bool bShouldEquipmentDegrade = false;
 					if ( (svFlags & SV_FLAG_FRIENDLYFIRE) )
 					{
@@ -796,6 +796,17 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					return;
 				}
 
+				// Test for Friendly Fire, if Friendly Fire is OFF, delete the missile
+				if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
+				{
+					if ( parent && parent->checkFriend(hit.entity) )
+					{
+						my->removeLightField();
+						list_RemoveNode(my->mynode);
+						return;
+					}
+				}
+
 				// check for magic resistance...
 				// resistance stacks diminishingly
 				//TODO: EFFECTS[EFF_MAGICRESIST]
@@ -853,15 +864,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
 							Entity* parent = uidToEntity(my->parent);
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 28, 128);
 							int damage = element->damage;
 							//damage += ((element->mana - element->base_mana) / static_cast<double>(element->overload_multiplier)) * element->damage;
@@ -980,16 +982,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
 							Entity* parent = uidToEntity(my->parent);
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent &&  parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 28, 128);
 							int damage = element->damage;
 							//damage += ((element->mana - element->base_mana) / static_cast<double>(element->overload_multiplier)) * element->damage;
@@ -1120,16 +1112,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 							}
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							//playSoundEntity(my, 153, 64);
 							playSoundEntity(hit.entity, 28, 128);
 							//TODO: Apply fire resistances/weaknesses.
@@ -1251,20 +1233,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									if ( my->light != NULL )
-									{
-										list_RemoveNode(my->light->node);
-										my->light = NULL;
-									}
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 174, 64);
 							hitstats->EFFECTS[EFF_CONFUSED] = true;
 							hitstats->EFFECTS_TIMERS[EFF_CONFUSED] = (element->duration * (((element->mana) / static_cast<double>(element->base_mana)) * element->overload_multiplier));
@@ -1315,16 +1283,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 172, 64);
 							hitstats->EFFECTS[EFF_SLOW] = true;
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] = (element->duration * (((element->mana) / static_cast<double>(element->base_mana)) * element->overload_multiplier));
@@ -1398,16 +1356,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 172, 64); //TODO: Slow spell sound.
 							hitstats->EFFECTS[EFF_SLOW] = true;
 							hitstats->EFFECTS_TIMERS[EFF_SLOW] = (element->duration * (((element->mana) / static_cast<double>(element->base_mana)) * element->overload_multiplier));
@@ -1457,16 +1405,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 174, 64);
 							hitstats->EFFECTS[EFF_ASLEEP] = true;
 							if ( parent && parent->behavior == &actMagicTrapCeiling )
@@ -1519,20 +1457,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						if (hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer)
 						{
 							Entity* parent = uidToEntity(my->parent);
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									if ( my->light != NULL )
-									{
-										list_RemoveNode(my->light->node);
-										my->light = NULL;
-									}
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(my, 173, 64);
 							playSoundEntity(hit.entity, 28, 128);
 							int damage = element->damage;
@@ -1935,20 +1859,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 					{
 						if ( hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer )
 						{
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									if ( my->light != NULL )
-									{
-										list_RemoveNode(my->light->node);
-										my->light = NULL;
-									}
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(hit.entity, 172, 64); //TODO: Paralyze spell sound.
 							hitstats->EFFECTS[EFF_PARALYZED] = true;
 							hitstats->EFFECTS_TIMERS[EFF_PARALYZED] = (element->duration * (((element->mana) / static_cast<double>(element->base_mana)) * element->overload_multiplier));
@@ -1998,16 +1908,6 @@ void actMagicMissile(Entity* my)   //TODO: Verify this function.
 						if ( hit.entity->behavior == &actMonster || hit.entity->behavior == &actPlayer )
 						{
 							Entity* parent = uidToEntity(my->parent);
-							if ( !(svFlags & SV_FLAG_FRIENDLYFIRE) )
-							{
-								// test for friendly fire
-								if ( parent && parent->checkFriend(hit.entity) )
-								{
-									my->removeLightField();
-									list_RemoveNode(my->mynode);
-									return;
-								}
-							}
 							playSoundEntity(my, 173, 64);
 							playSoundEntity(hit.entity, 28, 128);
 							int damage = element->damage;


### PR DESCRIPTION
This is a fix for #251 and #249.
The issue is that there is a repeating set of code checking to see if Friendly Fire is turned off. This is a small refactor to extract that to before the alerting code, checking to see if equipment should be damaged when reflecting, and preventing allies from being set on fire.