### PR TITLE
Fix Issue #241 - Minimap draws over Status Bar

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2809,12 +2809,6 @@ int main(int argc, char** argv)
 
 				if ( !gamePaused )
 				{
-					// status bar
-					if ( !nohud )
-					{
-						drawStatus();
-					}
-
 					// interface
 					if ( (*inputPressed(impulses[IN_STATUS]) || *inputPressed(joyimpulses[INJOY_STATUS])) )
 					{
@@ -3080,9 +3074,12 @@ int main(int argc, char** argv)
 							SDL_SetRelativeMouseMode(SDL_TRUE);
 						}
 					}
+
+					// Draw the static HUD elements
 					if ( !nohud )
 					{
-						drawMinimap();
+						drawMinimap(); // Draw the Minimap
+						drawStatus(); // Draw the Status Bar (Hotbar, Hungry/Minotaur Icons, Tooltips, etc.)
 					}
 
 					drawSustainedSpells();


### PR DESCRIPTION
This is a fix for #241.
The issue is that the Status Bar, which also draws Tooltips, executes before `drawMinimap()`. This simple rearrangement should be sufficient. Due to placing the `drawStatus()` call after a few other code blocks, there could be other side effects. This can be solved by rearranging a bit more.