### PR TITLE
Cmake clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 project(barony)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules)
@@ -36,6 +36,9 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 set(CMAKE_OSX_ARCHITECTURES x86_64)
+
+set(EDITOR_EXE_NAME "editor" CACHE STRING "Editor executable name")
+option(DATA_DIR "Points to install data directory" FALSE)
 
 if (STEAMWORKS_ENABLED)
 message("------------------------")
@@ -353,17 +356,26 @@ if (OPENAL)
   endif()
 endif()
 
+set(BASE_DATA_DIR "./" CACHE INTERNAL "Base data dir")
 
-if (NOT APPLE)
-#install(TARGETS barony
-#  RUNTIME DESTINATION bin
-#  COMPONENT Runtime
-#)
+if (NOT APPLE AND UNIX)
+include(GNUInstallDirs)
+if (DATA_DIR)
+	set(BASE_DATA_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/barony")
+endif()
+message(STATUS "Base data directory ${BASE_DATA_DIR}")
+
+install(TARGETS barony
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT Runtime
+)
 else()
 install(TARGETS barony
   RUNTIME DESTINATION bin COMPONENT Runtime BUNDLE DESTINATION Resources
 )
 endif()
+
+add_definitions(-DBASE_DATA_DIR=\"${BASE_DATA_DIR}\")
 
 if (APPLE)
   #add_executable(editor OSX/SDLmain.m ${EDITOR_SOURCES})
@@ -371,73 +383,85 @@ if (APPLE)
   #add_executable(editor MACOSX_BUNDLE OSX/SDLmain.m ${EDITOR_SOURCES} ${COPY_FRAMEWORKS} libfmodex.dylib  /opt/local/lib/libpng16.16.dylib)
   #add_executable(editor MACOSX_BUNDLE OSX/SDLmain.m ${EDITOR_SOURCES} libfmodex.dylib  /opt/local/lib/libpng16.16.dylib)
   if (FMOD_ENABLED)
-    add_executable(editor MACOSX_BUNDLE ${EDITOR_SOURCES} libfmodex.dylib  /opt/local/lib/libpng16.16.dylib)
+	  add_executable(${EDITOR_EXE_NAME} MACOSX_BUNDLE ${EDITOR_SOURCES} libfmodex.dylib  /opt/local/lib/libpng16.16.dylib)
   else()
-    add_executable(editor MACOSX_BUNDLE ${EDITOR_SOURCES} /opt/local/lib/libpng16.16.dylib)
+	  add_executable(${EDITOR_EXE_NAME} MACOSX_BUNDLE ${EDITOR_SOURCES} /opt/local/lib/libpng16.16.dylib)
   endif()
   #SET_SOURCE_FILES_PROPERTIES(${MACOSX_BUNDLE_ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
   set_source_files_properties(${EDITOR_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c++")
 else()
-  add_executable(editor ${EDITOR_SOURCES})
+	add_executable(${EDITOR_EXE_NAME} ${EDITOR_SOURCES})
 endif()
 
 if(WIN32)
-  target_link_libraries(editor -lmingw32)
-  target_link_libraries(editor -lSDL2main)
-  target_link_libraries(editor -lSDL2)
-  target_link_libraries(editor -lSDL2_net)
-  target_link_libraries(editor -lSDL2_image)
-  target_link_libraries(editor -lSDL2_ttf)
+	target_link_libraries(${EDITOR_EXE_NAME} -lmingw32)
+	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2main)
+	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2)
+	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_net)
+	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_image)
+	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_ttf)
   if(STEAMWORKS_ENABLED)
     #target_link_libraries(editor -lsteamworks_cwrapper -lstdc++)
-    target_link_libraries(editor -lsteam_api)
+    target_link_libraries(${EDITOR_EXE_NAME} -lsteam_api)
   endif()
 else()
   if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
     # 64 bit
-    target_link_libraries(editor -L/usr/lib64 -lstdc++)
+    target_link_libraries(${EDITOR_EXE_NAME} -L/usr/lib64 -lstdc++)
   endif()
-  target_link_libraries(editor ${SDL2_LIBRARIES} ${SDL2_LIBRARY} ${SDL2IMAGE_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_NET_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${SDL2TTF_LIBRARY})
+  target_link_libraries(${EDITOR_EXE_NAME} ${SDL2_LIBRARIES} ${SDL2_LIBRARY} ${SDL2IMAGE_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_NET_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${SDL2TTF_LIBRARY})
   if (STEAMWORKS_ENABLED)
-    target_link_libraries(editor ${STEAMWORKS_LIBRARY})
+	  target_link_libraries(${EDITOR_EXE_NAME} ${STEAMWORKS_LIBRARY})
     #target_link_libraries(editor ${STEAMWORKS_CWRAPPER_LIBRARIES} -lstdc++)
   endif()
 endif()
-target_link_libraries(editor ${OPENGL_LIBRARIES})
-target_link_libraries(editor ${THREADS_LIBRARIES})
-target_link_libraries(editor -lm)
+target_link_libraries(${EDITOR_EXE_NAME} ${OPENGL_LIBRARIES})
+target_link_libraries(${EDITOR_EXE_NAME} ${THREADS_LIBRARIES})
+target_link_libraries(${EDITOR_EXE_NAME} -lm)
 # We need to link to Winsock if we're on Windows
 if( NOT WIN32 AND NOT APPLE)
   #Remember, Windows and Mac aren't using find_package for FMOD and PNG.
-  target_link_libraries(editor ${PNG_LIBRARY})
+  target_link_libraries(${EDITOR_EXE_NAME} ${PNG_LIBRARY})
   if (FMOD_FOUND)
-    target_link_libraries(editor ${FMOD_LIBRARY})
+	  target_link_libraries(${EDITOR_EXE_NAME} ${FMOD_LIBRARY})
   endif()
 endif()
 if(WIN32)
-  target_link_libraries(editor wsock32 ws2_32)
-  target_link_libraries(editor -lfmodex)
+	target_link_libraries(${EDITOR_EXE_NAME} wsock32 ws2_32)
+	target_link_libraries(${EDITOR_EXE_NAME} -lfmodex)
 endif()
 if (APPLE)
   if (FMOD_ENABLED)
-    target_link_libraries(editor -lfmodex) #Finally manually link fmod for mac.
+	  target_link_libraries(${EDITOR_EXE_NAME} -lfmodex) #Finally manually link fmod for mac.
   endif()
 endif()
-target_link_libraries(editor ${EXTRA_LIBS}) #Apple needs this for OpenGL to work.
+target_link_libraries(${EDITOR_EXE_NAME} ${EXTRA_LIBS}) #Apple needs this for OpenGL to work.
 if (OPENAL)
-  target_link_libraries(editor ${OPENAL_LIBRARY})
+	target_link_libraries(${EDITOR_EXE_NAME} ${OPENAL_LIBRARY})
   if(TREMOR_ENABLED)
-    target_link_libraries(editor ${TREMOR_LIBRARY})
+	  target_link_libraries(${EDITOR_EXE_NAME} ${TREMOR_LIBRARY})
   else()
-    target_link_libraries(editor ${VORBISFILE_LIBRARY})
+	  target_link_libraries(${EDITOR_EXE_NAME} ${VORBISFILE_LIBRARY})
   endif()
 endif()
 
-#install(TARGETS editor
-#  RUNTIME DESTINATION bin COMPONENT Runtime
-#)
+if (NOT APPLE AND UNIX)
+	install(TARGETS ${EDITOR_EXE_NAME}
+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
+	)
 
-#install(DIRECTORY data DESTINATION share/barony )
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lang DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+
+	if (EXISTS books)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/books DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/images DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/items DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/maps DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/models DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/music DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/sound DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+	endif()
+endif()
 
 if (APPLE)
 #  SET_TARGET_PROPERTIES(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,20 +359,20 @@ endif()
 set(BASE_DATA_DIR "./" CACHE INTERNAL "Base data dir")
 
 if (NOT APPLE AND UNIX)
-include(GNUInstallDirs)
-if (DATA_DIR)
-	set(BASE_DATA_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/barony")
-endif()
-message(STATUS "Base data directory ${BASE_DATA_DIR}")
+  include(GNUInstallDirs)
+  if (DATA_DIR)
+    set(BASE_DATA_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/barony")
+  endif()
+  message(STATUS "Base data directory ${BASE_DATA_DIR}")
 
-install(TARGETS barony
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT Runtime
-)
+  install(TARGETS barony
+	 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   COMPONENT Runtime
+  )
 else()
-install(TARGETS barony
-  RUNTIME DESTINATION bin COMPONENT Runtime BUNDLE DESTINATION Resources
-)
+  install(TARGETS barony
+    RUNTIME DESTINATION bin COMPONENT Runtime BUNDLE DESTINATION Resources
+  )
 endif()
 
 add_definitions(-DBASE_DATA_DIR=\"${BASE_DATA_DIR}\")
@@ -394,12 +394,7 @@ else()
 endif()
 
 if(WIN32)
-	target_link_libraries(${EDITOR_EXE_NAME} -lmingw32)
-	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2main)
-	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2)
-	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_net)
-	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_image)
-	target_link_libraries(${EDITOR_EXE_NAME} -lSDL2_ttf)
+	target_link_libraries(${EDITOR_EXE_NAME} -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lSDL2_image -lSDL2_ttf)
   if(STEAMWORKS_ENABLED)
     #target_link_libraries(editor -lsteamworks_cwrapper -lstdc++)
     target_link_libraries(${EDITOR_EXE_NAME} -lsteam_api)
@@ -446,21 +441,19 @@ if (OPENAL)
 endif()
 
 if (NOT APPLE AND UNIX)
-	install(TARGETS ${EDITOR_EXE_NAME}
-		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
-	)
+  install(TARGETS ${EDITOR_EXE_NAME}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
+  )
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lang DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lang DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
 
-	if (EXISTS books)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/books DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/images DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/items DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/maps DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/models DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/music DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-		install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/sound DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony)
-	endif()
+  if (EXISTS books)
+    install(DIRECTORY 
+        ${CMAKE_CURRENT_BINARY_DIR}/books ${CMAKE_CURRENT_BINARY_DIR}/images ${CMAKE_CURRENT_BINARY_DIR}/items
+        ${CMAKE_CURRENT_BINARY_DIR}/maps ${CMAKE_CURRENT_BINARY_DIR}/models ${CMAKE_CURRENT_BINARY_DIR}/music
+        ${CMAKE_CURRENT_BINARY_DIR}/sound DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/barony
+    )
+  endif()
 endif()
 
 if (APPLE)

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -921,7 +921,9 @@ void redo()
 void processCommandLine(int argc, char** argv)
 {
 	int c = 0;
-	strcpy(datadir, "./");
+	size_t datadirsz = std::min(sizeof(datadir) - 1, strlen(BASE_DATA_DIR));
+	strncpy(datadir, BASE_DATA_DIR, datadirsz);
+	datadir[datadirsz] = '\0';
 	if ( argc > 1 )
 	{
 		for ( c = 1; c < argc; c++ )
@@ -935,7 +937,9 @@ void processCommandLine(int argc, char** argv)
 				}
 				else if (!strncmp(argv[c], "-datadir=", 9))
 				{
-					strcpy(datadir, argv[c] + 9);
+					datadirsz = std::min(sizeof(datadir) - 1, strlen(argv[c] + 9));
+					strncpy(datadir, argv[c] + 9, datadirsz);
+					datadir[datadirsz] = '\0';
 				}
 			}
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2234,7 +2234,9 @@ int main(int argc, char** argv)
 		//SDL_Surface *sky_bmp;
 		light_t* light;
 
-		strcpy(datadir, "./");
+		size_t datadirsz = std::min(sizeof(datadir) - 1, strlen(BASE_DATA_DIR));
+		strncpy(datadir, BASE_DATA_DIR, datadirsz);
+		datadir[datadirsz] = '\0';
 		// read command line arguments
 		if ( argc > 1 )
 		{
@@ -2274,7 +2276,9 @@ int main(int argc, char** argv)
 					}
 					else if (!strncmp(argv[c], "-datadir=", 9))
 					{
-						strcpy(datadir, argv[c] + 9);
+						datadirsz = std::min(sizeof(datadir) - 1, strlen(argv[c] + 9));
+						strncpy(datadir, argv[c] + 9, datadirsz);
+						datadir[datadirsz] = '\0';
 					}
 				}
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int mainloop = 1;
 bool initialized = false;
 Uint32 ticks = 0;
 bool stop = false;
-char datadir[1024];
+char datadir[PATH_MAX];
 
 // language stuff
 char languageCode[32] = { 0 };

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -42,11 +42,13 @@ extern bool showfirst;
 #include <fcntl.h>
 #ifndef WINDOWS
 #include <unistd.h>
+#include <limits.h>
 #endif
 #include <string.h>
 #include <ctype.h>
 #ifdef WINDOWS
 #define GL_GLEXT_PROTOTYPES
+#define PATH_MAX 1024
 #include <windows.h>
 #undef min
 #undef max
@@ -705,7 +707,7 @@ extern GLuint fbo_ren;
 #endif
 void GO_SwapBuffers(SDL_Window* screen);
 unsigned int GO_GetPixelU32(int x, int y);
-extern char datadir[1024];
+extern char datadir[PATH_MAX];
 FILE *openDataFile(const char *const filename, const char * const mode);
 DIR * openDataDir(const char *const);
 bool dataPathExists(const char *const);


### PR DESCRIPTION
I started to work on packaging barony for *BSD systems thus the need to be able to install them properly with the help of the handy GNUInstallDir plugin, possibility to rename editor binary to avoid possible conflicts. I did not apply purposely for Darwin machines as I  was not sure @addictgamer would like (probably on these, only GOG and Steam are planned ... not home-brew/MacPorts ?).

