### PR TITLE
SDL_SavePNG: fail softly

### DIFF
--- a/src/savepng.cpp
+++ b/src/savepng.cpp
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include "png.h"
 
+#include "savepng.hpp"
+
 #define SUCCESS 0
 #define ERROR -1
 
@@ -24,6 +26,19 @@
 #define bmask 0x00FF0000
 #define amask 0xFF000000
 #endif
+
+int SDL_SavePNG(SDL_Surface *surface, const char *filename)
+{
+	SDL_RWops *file = SDL_RWFromFile(filename, "wb");
+	if (file != NULL)
+	{
+		return SDL_SavePNG_RW(surface, file, 1);
+	}
+	else
+	{
+		return -1;
+	}
+}
 
 /* libpng callbacks */
 static void png_error_SDL(png_structp ctx, png_const_charp str)

--- a/src/savepng.hpp
+++ b/src/savepng.hpp
@@ -17,8 +17,7 @@
  * Returns 0 success or -1 on failure, the error message is then retrievable
  * via SDL_GetError().
  */
-#define SDL_SavePNG(surface, file) \
-	SDL_SavePNG_RW(surface, SDL_RWFromFile(file, "wb"), 1)
+int SDL_SavePNG(SDL_Surface *surface, const char *file);
 
 /*
  * Save an SDL_Surface as a PNG file, using writable RWops.


### PR DESCRIPTION
Previously, SDL_SavePNG would crash if the file could not be opened.