### PR TITLE
Beta hotfix for friendly fire OFF

### DIFF
--- a/lang/en.txt
+++ b/lang/en.txt
@@ -3208,9 +3208,6 @@ incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
 exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.#
 
 2601
-
-
-
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.#

--- a/lang/en.txt
+++ b/lang/en.txt
@@ -3182,7 +3182,7 @@ Difficulty: Normal#
 Difficulty: Normal#
 
 # More misc.
-2570 https://www.surveymonkey.com/r/6TC5T9W#
+2570 https://docs.google.com/forms/d/e/1FAIpQLScywW5ROX4m8cp05PspI7xZNV0jkEPAWJu3lWegS9Tj9NBDOg/viewform#
 2571 Weapons#
 2572 Armor#
 2573 Jewelry#

--- a/lang/en.txt
+++ b/lang/en.txt
@@ -3182,7 +3182,7 @@ Difficulty: Normal#
 Difficulty: Normal#
 
 # More misc.
-2570 http://www.baronygame.com/#
+2570 https://www.surveymonkey.com/r/6TC5T9W#
 2571 Weapons#
 2572 Armor#
 2573 Jewelry#
@@ -3196,7 +3196,7 @@ Difficulty: Normal#
 2581 Food#
 2582 Spells#
 2583 Item Categories for Auto Hotbar:#
-2584 http://www.baronygame.com/#
+2584 Click here to provide feedback for the Beta!#
 
 2585 A big shoutout to the open source community for their contributions!#
 2586 #
@@ -3208,6 +3208,9 @@ incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostr
 exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.#
 
 2601
+
+
+
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
 culpa qui officia deserunt mollit anim id est laborum.#

--- a/src/item_usage_funcs.cpp
+++ b/src/item_usage_funcs.cpp
@@ -1470,7 +1470,7 @@ void item_ScrollEnchantArmor(Item* item, int player)
 			messagePlayer(player, language[857]);
 		}
 	}
-	else
+	else if ( armor != nullptr )
 	{
 		if (item->beatitude < 0)
 		{
@@ -1925,11 +1925,11 @@ void item_ScrollRepair(Item* item, int player)
 		}
 	}
 
-	if ( armor == NULL && player == clientnum )
+	if ( armor == nullptr && player == clientnum )
 	{
 		messagePlayer(player, language[870]);
 	}
-	else
+	else if ( armor != nullptr )
 	{
 		if ( item->beatitude < 0 && player == clientnum )
 		{

--- a/src/magic/castSpell.cpp
+++ b/src/magic/castSpell.cpp
@@ -1158,13 +1158,53 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 	{
 		if ( using_magicstaff )
 		{
-			if ( rand() % 6 == 0 ) //16.67%
+			if ( stat )
 			{
-				caster->increaseSkill(PRO_SPELLCASTING);
-			}
-			if ( rand() % 7 == 0 ) //14.2%
-			{
-				caster->increaseSkill(PRO_MAGIC);
+				// spellcasting increase chances.
+				if ( stat->PROFICIENCIES[PRO_SPELLCASTING] < 60 )
+				{
+					if ( rand() % 6 == 0 ) //16.67%
+					{
+						caster->increaseSkill(PRO_SPELLCASTING);
+					}
+				}
+				else if ( stat->PROFICIENCIES[PRO_SPELLCASTING] < 80 )
+				{
+					if ( rand() % 9 == 0 ) //11.11%
+					{
+						caster->increaseSkill(PRO_SPELLCASTING);
+					}
+				}
+				else // greater than 80
+				{
+					if ( rand() % 12 == 0 ) //8.33%
+					{
+						caster->increaseSkill(PRO_SPELLCASTING);
+					}
+				}
+
+				// magic increase chances.
+				if ( stat->PROFICIENCIES[PRO_MAGIC] < 60 )
+				{
+					if ( rand() % 7 == 0 ) //14.2%
+					{
+						caster->increaseSkill(PRO_MAGIC);
+					}
+				}
+				else if ( stat->PROFICIENCIES[PRO_MAGIC] < 80 )
+				{
+					if ( rand() % 10 == 0 ) //10.00%
+					{
+						caster->increaseSkill(PRO_MAGIC);
+					}
+				}
+				else // greater than 80
+				{
+					if ( rand() % 13 == 0 ) //7.69%
+					{
+						caster->increaseSkill(PRO_MAGIC);
+					}
+				}
 			}
 		}
 		else

--- a/src/magic/magic.cpp
+++ b/src/magic/magic.cpp
@@ -326,8 +326,8 @@ void spellEffectAcid(Entity& my, spellElement_t& element, Entity* parent, int re
 				// test for friendly fire
 				if ( parent && parent->checkFriend(hit.entity) )
 				{
-					my.removeLightField();
-					list_RemoveNode(my.mynode);
+					/*my.removeLightField();
+					list_RemoveNode(my.mynode);*/
 					return;
 				}
 			}
@@ -458,8 +458,8 @@ void spellEffectStealWeapon(Entity& my, spellElement_t& element, Entity* parent,
 				// test for friendly fire
 				if ( parent && parent->checkFriend(hit.entity) )
 				{
-					my.removeLightField();
-					list_RemoveNode(my.mynode);
+					/*my.removeLightField();
+					list_RemoveNode(my.mynode);*/
 					return;
 				}
 			}
@@ -602,8 +602,8 @@ void spellEffectDrainSoul(Entity& my, spellElement_t& element, Entity* parent, i
 				// test for friendly fire
 				if ( parent && parent->checkFriend(hit.entity) )
 				{
-					my.removeLightField();
-					list_RemoveNode(my.mynode);
+					/*my.removeLightField();
+					list_RemoveNode(my.mynode);*/
 					return;
 				}
 			}

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -174,13 +174,19 @@ int monsterCurve(int level)
 	}
 	else if ( !strncmp(map.name, "Hell", 4) )     // hell
 	{
-		switch ( rand() % 10 )
+		switch ( rand() % 20 )
 		{
 			case 0:
 			case 1:
 				return SUCCUBUS;
 			case 2:
 			case 3:
+				return INCUBUS;
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
 				if ( strstr(map.name, "Boss") )
 				{
 					return DEMON;    // we would otherwise lag bomb on the boss level
@@ -189,14 +195,20 @@ int monsterCurve(int level)
 				{
 					return CREATURE_IMP;
 				}
-			case 4:
-			case 5:
-				return SHADOW;
-			case 6:
-			case 7:
-			case 8:
 			case 9:
+			case 10:
+			case 11:
+			case 12:
+			case 13:
+			case 14:
 				return DEMON;
+			case 15:
+			case 16:
+			case 17:
+			case 18:
+				return GOATMAN;
+			case 19:
+				return SHADOW;
 		}
 	}
 	else if ( !strncmp(map.name, "Caves", 5) )


### PR DESCRIPTION
Fixes crashing for server, occurs when spray acid or drain soul is cast on a monster that is a "friend". Only when FF is disabled. Otherwise damages as normal.

Also spaced out the text scroll to stop it overlapping for most resolutions.