### PR TITLE
Include short git hash in version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,21 @@ message("Building without steamworks")
 message("------------------------")
 endif()
 
+# REMEMBER TO CHANGE THIS WITH EVERY NEW OFFICIAL VERSION!!!
+set(VERSION "3.0.2")
+find_package(Git)
+if (Git_FOUND)
+  # It would be nice to use `git describe` to get the whole version string from
+  # git, but we don't have the appropriate tagging discipline in the repo (yet?)
+  exec_program("${GIT_EXECUTABLE}"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    ARGS "rev-parse --short HEAD"
+    OUTPUT_VARIABLE VERSION_HASH
+  )
+  set(VERSION "${VERSION}-${VERSION_HASH}")
+endif(Git_FOUND)
+
+
 set (Apple 0)
 set (Windows 0)
 set (Linux 0)
@@ -71,11 +86,10 @@ if( NOT WIN32 )
     #set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -x objective-c")
     set(MACOSX_BUNDLE true)
     set(MACOSX_BUNDLE_BUNDLE_NAME Barony)
-    #TODO: Make version a define which is also set in src/Config.h
-    set(MACOSX_BUNDLE_INFO_STRING Barony 2.0.2)
-    set(MACOSX_BUNDLE_LONG_VERSION 2.0.2)
-    set(MACOSX_BUNDLE_SHORT_VERSION_STRING 2.0.2)
-    set(MACOSX_BUNDLE_BUNDLE_VERSION 2.0.2)
+    set(MACOSX_BUNDLE_INFO_STRING Barony "${VERSION}")
+    set(MACOSX_BUNDLE_LONG_VERSION "${VERSION}")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION}")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION}")
     set(MACOSX_BUNDLE_ICON_FILE "barony.icns")
     #set(MACOSX_BUNDLE_ICON_FILE "game.icns")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -std=c++11 -stdlib=libc++")

--- a/src/Config.hpp.in
+++ b/src/Config.hpp.in
@@ -40,3 +40,5 @@
 	 */
 	typedef unsigned long DWORD;
 #endif
+
+#define VERSION "v@VERSION@"

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -14,8 +14,6 @@
 #include <vector>
 #include <random>
 
-// REMEMBER TO CHANGE THIS WITH EVERY NEW OFFICIAL VERSION!!!
-#define VERSION "v3.0.1"
 #define GAME_CODE
 
 //#define MAX_FPS_LIMIT 60 //TODO: Make this configurable.


### PR DESCRIPTION
This can make tracing issues back to the code a lot easier, especially
with steam versions, for people who do not know what happens to be the
current version on Steam etc., see #312