### PR TITLE
Fix Issue #48 - Client Remove Curse Spell does not open GUI

### DIFF
--- a/src/interface/identify_and_appraise.cpp
+++ b/src/interface/identify_and_appraise.cpp
@@ -79,6 +79,12 @@ void rebuildIdentifyGUIInventory()
 	}
 }
 
+void CloseIdentifyGUI()
+{
+	identifygui_active = false;
+	selectedIdentifySlot = -1;
+}
+
 void updateIdentifyGUI()
 {
 	//if (openedChest[clientnum])

--- a/src/interface/interface.hpp
+++ b/src/interface/interface.hpp
@@ -220,6 +220,7 @@ extern int selectedIdentifySlot;
 void selectIdentifySlot(int slot);
 void warpMouseToSelectedIdentifySlot();
 
+void CloseIdentifyGUI();
 void updateIdentifyGUI(); //Updates the identify item GUI.
 void identifyGUIIdentify(Item* item); //Identify the given item.
 int getAppraisalTime(Item* item); // Return time in ticks needed to appraise an item

--- a/src/magic/castSpell.cpp
+++ b/src/magic/castSpell.cpp
@@ -569,7 +569,7 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 					if (i != 0)
 					{
 						//Tell the client to uncurse an item.
-						strcpy((char*)net_packet->data, "RCUR"); //TODO: Send a different packet, to pop open the remove curse GUI.
+						strcpy((char*)net_packet->data, "CRCU");
 						net_packet->address.host = net_clients[i - 1].host;
 						net_packet->address.port = net_clients[i - 1].port;
 						net_packet->len = 4;
@@ -582,6 +582,12 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 						gui_mode = GUI_MODE_INVENTORY; //Reset the GUI to the inventory.
 						removecursegui_active = true;
 						identifygui_active = false;
+
+						if ( identifygui_active )
+						{
+							CloseIdentifyGUI();
+						}
+
 						if ( openedChest[i] )
 						{
 							openedChest[i]->closeChest();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2727,6 +2727,28 @@ void clientHandlePacket()
 		return;
 	}
 
+	// Open up the Remove Curse GUI
+	else if ( !strncmp((char*)net_packet->data, "CRCU", 4) )
+	{
+		removecursegui_active = true;
+		shootmode = false;
+		gui_mode = GUI_MODE_INVENTORY;
+
+		if ( identifygui_active )
+		{
+			CloseIdentifyGUI();
+		}
+
+		if ( openedChest[clientnum] )
+		{
+			openedChest[clientnum]->closeChest();
+		}
+
+		initRemoveCurseGUIControllerCode();
+
+		return;
+	}
+
 	//Add a spell to the channeled spells list.
 	else if (!strncmp((char*)net_packet->data, "CHAN", 4))
 	{


### PR DESCRIPTION
This is a fix for #48.
The issue is that there was never a packet implemented to handle opening the GUI. All of the functionality already existed and works, but nothing ever called the GUI on the Client. Packet 'CRCU' was added to fix this.

Additionally, a function was added 'CloseIdentifyGUI()' to improve consistency. This is a temporary fix until #177 is fixed.