### PR TITLE
Enhancement - Identify & Remove Curse Scrolls use GUI

### DIFF
--- a/src/interface/identify_and_appraise.cpp
+++ b/src/interface/identify_and_appraise.cpp
@@ -79,6 +79,12 @@ void rebuildIdentifyGUIInventory()
 	}
 }
 
+void CloseIdentifyGUI()
+{
+	identifygui_active = false;
+	selectedIdentifySlot = -1;
+}
+
 void updateIdentifyGUI()
 {
 	//if (openedChest[clientnum])

--- a/src/interface/interface.hpp
+++ b/src/interface/interface.hpp
@@ -220,6 +220,7 @@ extern int selectedIdentifySlot;
 void selectIdentifySlot(int slot);
 void warpMouseToSelectedIdentifySlot();
 
+void CloseIdentifyGUI();
 void updateIdentifyGUI(); //Updates the identify item GUI.
 void identifyGUIIdentify(Item* item); //Identify the given item.
 int getAppraisalTime(Item* item); // Return time in ticks needed to appraise an item

--- a/src/item_usage_funcs.cpp
+++ b/src/item_usage_funcs.cpp
@@ -1230,10 +1230,6 @@ void item_ScrollMail(Item* item, int player)
 
 void item_ScrollIdentify(Item* item, int player)
 {
-	node_t* node;
-	Item* target;
-	int c, items, itemToIdentify, numIdentified = 0;
-
 	if (players[player] == nullptr || players[player]->entity == nullptr)
 	{
 		return;
@@ -1250,57 +1246,24 @@ void item_ScrollIdentify(Item* item, int player)
 		return;
 	}
 
-	if ( player == clientnum )
-	{
-		conductIlliterate = false;
-	}
-	item->identified = 1;
-	messagePlayer(player, language[848]);
-	messagePlayer(player, language[849]);
+	//identifygui_mode = true;
+	identifygui_active = true;
+	identifygui_appraising = false;
+	shootmode = false;
+	gui_mode = GUI_MODE_INVENTORY; //Reset the GUI to the inventory.
 
-	// identify algorithm: locate unidentified inventory items and randomly choose
-	// one of them to be identified. Each item has equal chance of being identified.
-	// cursed = 1 item identified
-	// uncursed = 1 item identified
-	// blessed = 1+ items identified
-
-	for ( c = 0; c < std::max(item->beatitude + 1, 1); c++ )
+	if ( removecursegui_active )
 	{
-		items = 0;
-		for ( node = stats[player]->inventory.first; node != NULL; node = node->next )
-		{
-			target = (Item*)node->element;
-			if ( target && target->identified == false )
-			{
-				items++;
-			}
-		}
-		if ( items == 0 )
-		{
-			if ( numIdentified == 0 )
-			{
-				messagePlayer(player, language[850]);
-			}
-			break;
-		}
-		itemToIdentify = rand() % items;
-		items = 0;
-		for ( node = stats[player]->inventory.first; node != NULL; node = node->next )
-		{
-			target = (Item*)node->element;
-			if ( target && target->identified == false )
-			{
-				if ( items == itemToIdentify )
-				{
-					target->identified = true;
-					numIdentified++;
-					messagePlayer(player, " * %s.", target->description());
-					break;
-				}
-				items++;
-			}
-		}
+		closeRemoveCurseGUI();
 	}
+
+	if ( openedChest[clientnum] )
+	{
+		openedChest[clientnum]->closeChest();
+	}
+
+	//Initialize Identify GUI game controller code here.
+	initIdentifyGUIControllerCode();
 }
 
 void item_ScrollLight(Item* item, int player)
@@ -1574,7 +1537,7 @@ void item_ScrollEnchantArmor(Item* item, int player)
 void item_ScrollRemoveCurse(Item* item, int player)
 {
 	Item* target = nullptr;
-	node_t* node;
+
 	if (players[player] == nullptr || players[player]->entity == nullptr)
 	{
 		return;
@@ -1589,67 +1552,27 @@ void item_ScrollRemoveCurse(Item* item, int player)
 		return;
 	}
 
-	if (player == clientnum)
-	{
-		conductIlliterate = false;
-	}
-	item->identified = 1;
-	if (player == clientnum)
-	{
-		messagePlayer(player, language[848]);
-	}
 	if (item->beatitude >= 0)
 	{
-		if (player == clientnum)
+		// Uncurse an item
+		shootmode = false;
+		gui_mode = GUI_MODE_INVENTORY; // Reset the GUI to the inventory.
+		removecursegui_active = true;
+		identifygui_active = false;
+
+		if ( identifygui_active )
 		{
-			messagePlayer(player, language[861]);
+			CloseIdentifyGUI();
 		}
-		if (stats[player]->helmet != nullptr)
+
+		if ( openedChest[player] )
 		{
-			stats[player]->helmet->beatitude = std::max<Sint16>(0, stats[player]->helmet->beatitude);
+			openedChest[player]->closeChest();
 		}
-		if (stats[player]->breastplate != nullptr)
-		{
-			stats[player]->breastplate->beatitude = std::max<Sint16>(0, stats[player]->breastplate->beatitude);
-		}
-		if (stats[player]->gloves != nullptr)
-		{
-			stats[player]->gloves->beatitude = std::max<Sint16>(0, stats[player]->gloves->beatitude);
-		}
-		if (stats[player]->shoes != nullptr)
-		{
-			stats[player]->shoes->beatitude = std::max<Sint16>(0, stats[player]->shoes->beatitude);
-		}
-		if (stats[player]->shield != nullptr)
-		{
-			stats[player]->shield->beatitude = std::max<Sint16>(0, stats[player]->shield->beatitude);
-		}
-		if (stats[player]->weapon != nullptr)
-		{
-			stats[player]->weapon->beatitude = std::max<Sint16>(0, stats[player]->weapon->beatitude);
-		}
-		if (stats[player]->cloak != nullptr)
-		{
-			stats[player]->cloak->beatitude = std::max<Sint16>(0, stats[player]->cloak->beatitude);
-		}
-		if (stats[player]->amulet != nullptr)
-		{
-			stats[player]->amulet->beatitude = std::max<Sint16>(0, stats[player]->amulet->beatitude);
-		}
-		if (stats[player]->ring != nullptr)
-		{
-			stats[player]->ring->beatitude = std::max<Sint16>(0, stats[player]->ring->beatitude);
-		}
-		if (stats[player]->mask != nullptr)
-		{
-			stats[player]->mask->beatitude = std::max<Sint16>(0, stats[player]->mask->beatitude);
-		}
-		if (item->beatitude > 0 && player == clientnum )
-			for (node = stats[player]->inventory.first; node != nullptr; node = node->next)
-			{
-				target = (Item*)node->element;
-				target->beatitude = std::max<Sint16>(0, target->beatitude);
-			}
+
+		initRemoveCurseGUIControllerCode();
+
+		return;
 	}
 	else
 	{

--- a/src/magic/castSpell.cpp
+++ b/src/magic/castSpell.cpp
@@ -569,7 +569,7 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 					if (i != 0)
 					{
 						//Tell the client to uncurse an item.
-						strcpy((char*)net_packet->data, "RCUR"); //TODO: Send a different packet, to pop open the remove curse GUI.
+						strcpy((char*)net_packet->data, "CRCU");
 						net_packet->address.host = net_clients[i - 1].host;
 						net_packet->address.port = net_clients[i - 1].port;
 						net_packet->len = 4;
@@ -582,6 +582,12 @@ Entity* castSpell(Uint32 caster_uid, spell_t* spell, bool using_magicstaff, bool
 						gui_mode = GUI_MODE_INVENTORY; //Reset the GUI to the inventory.
 						removecursegui_active = true;
 						identifygui_active = false;
+
+						if ( identifygui_active )
+						{
+							CloseIdentifyGUI();
+						}
+
 						if ( openedChest[i] )
 						{
 							openedChest[i]->closeChest();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2727,6 +2727,28 @@ void clientHandlePacket()
 		return;
 	}
 
+	// Open up the Remove Curse GUI
+	else if ( !strncmp((char*)net_packet->data, "CRCU", 4) )
+	{
+		removecursegui_active = true;
+		shootmode = false;
+		gui_mode = GUI_MODE_INVENTORY;
+
+		if ( identifygui_active )
+		{
+			CloseIdentifyGUI();
+		}
+
+		if ( openedChest[clientnum] )
+		{
+			openedChest[clientnum]->closeChest();
+		}
+
+		initRemoveCurseGUIControllerCode();
+
+		return;
+	}
+
 	//Add a spell to the channeled spells list.
 	else if (!strncmp((char*)net_packet->data, "CHAN", 4))
 	{


### PR DESCRIPTION
This is an enhancement to the Identify and Remove Curse Scrolls to make them use the preexisting GUI, rather than using custom logic (random logic).

Note: This is a simple change, it does not change any existing logic to cursed scrolls, or add anything. It will still use the scroll even if there is nothing to Identify or Uncurse. It will still use the Scroll even if they close the GUI before selecting.