### PR TITLE
Fix crash startup.

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -12392,7 +12392,7 @@ bool gamemodsClearAllMountedPaths()
 	for ( i = PHYSFS_getSearchPath(); *i != NULL; i++ )
 	{
 		std::string line = *i;
-		if ( line.compare(outputdir) != 0 && line.compare("./") != 0 ) // don't unmount the base ./ directory
+		if ( line.compare(outputdir) != 0 && line.compare(datadir) != 0 && line.compare("./") != 0 ) // don't unmount the base ./ directory
 		{
 			if ( PHYSFS_unmount(*i) == 0 )
 			{


### PR DESCRIPTION
The datadir could be unmounted thus leading to crash
when trying to load levels later on.