### PR TITLE
* v3.2.2 Further tile bucket optimizations

### DIFF
--- a/lang/en.txt
+++ b/lang/en.txt
@@ -3895,4 +3895,7 @@ locked/unlocked in-game by left clicking the lock symbol on the HUD page.#
 3157 Always shows the in-game timer when the inventory is closed in the upper right-hand section of 
 the screen. Useful to track speedrun times, when the minotaur will arrive, or how long your
 current food situation will last.#
+
+3158 mute audio when game window focus is lost#
+
 3199 end#

--- a/lang/en.txt
+++ b/lang/en.txt
@@ -3897,5 +3897,6 @@ the screen. Useful to track speedrun times, when the minotaur will arrive, or ho
 current food situation will last.#
 
 3158 mute audio when game window focus is lost#
+3159 Show Numerical Skill Values#
 
 3199 end#

--- a/src/actboulder.cpp
+++ b/src/actboulder.cpp
@@ -85,6 +85,10 @@ bool doesEntityStopBoulder(Entity* entity)
 	{
 		return true;
 	}
+	else if ( entity->behavior == &actColumn )
+	{
+		return true;
+	}
 	return false;
 }
 
@@ -273,6 +277,15 @@ int boulderCheckAgainstEntity(Entity* my, Entity* entity)
 			{
 				entity->skill[6] = (my->y < entity->y);
 			}
+			playSoundEntity(my, 181, 128);
+		}
+	}
+	else if ( entity->behavior == &actFurniture )
+	{
+		if ( entityInsideEntity(my, entity) )
+		{
+			playSoundEntity(entity, 28, 64);
+			entity->furnitureHealth = 0;
 			playSoundEntity(my, 181, 128);
 		}
 	}
@@ -744,11 +757,7 @@ void actBoulderTrap(Entity* my)
 	{
 		if ( !BOULDERTRAP_FIRED )
 		{
-			playSoundEntity(my, 150, 128);
-			for ( c = 0; c < MAXPLAYERS; c++ )
-			{
-				playSoundPlayer(c, 150, 64);
-			}
+			int foundTrapdoor = -1;
 			BOULDERTRAP_FIRED = 1;
 			for ( c = 0; c < 4; c++ )
 			{
@@ -780,17 +789,16 @@ void actBoulderTrap(Entity* my)
 						if ( !map.tiles[OBSTACLELAYER + y * MAPLAYERS + x * MAPLAYERS * map.height] )
 						{
 							list_t* trapdoors = TileEntityList.getTileList(x, y);
-							bool foundTrapdoor = false;
 							for ( node_t* trapNode = trapdoors->first; trapNode != nullptr; trapNode = trapNode->next )
 							{
 								Entity* trapEntity = (Entity*)trapNode->element;
 								if ( trapEntity && trapEntity->sprite == 252 && trapEntity->z <= -10 )
 								{
-									foundTrapdoor = true;
+									foundTrapdoor = c;
 									break;
 								}
 							}
-							if ( foundTrapdoor )
+							if ( foundTrapdoor == c )
 							{
 								Entity* entity = newEntity(245, 1, map.entities, nullptr); // boulder
 								entity->parent = my->getUID();
@@ -818,6 +826,14 @@ void actBoulderTrap(Entity* my)
 							}
 						}
 					}
+				}
+			}
+			if ( foundTrapdoor >= 0 )
+			{
+				playSoundEntity(my, 150, 128);
+				for ( c = 0; c < MAXPLAYERS; c++ )
+				{
+					playSoundPlayer(c, 150, 64);
 				}
 			}
 		}

--- a/src/actboulder.cpp
+++ b/src/actboulder.cpp
@@ -779,29 +779,43 @@ void actBoulderTrap(Entity* my)
 					{
 						if ( !map.tiles[OBSTACLELAYER + y * MAPLAYERS + x * MAPLAYERS * map.height] )
 						{
-							Entity* entity = newEntity(245, 1, map.entities, nullptr); // boulder
-							entity->parent = my->getUID();
-							entity->x = (x << 4) + 8;
-							entity->y = (y << 4) + 8;
-							entity->z = -64;
-							entity->yaw = c * (PI / 2.f);
-							entity->sizex = 7;
-							entity->sizey = 7;
-							if ( checkObstacle(entity->x + cos(entity->yaw) * 16, entity->y + sin(entity->yaw) * 16, entity, NULL) )
+							list_t* trapdoors = TileEntityList.getTileList(x, y);
+							bool foundTrapdoor = false;
+							for ( node_t* trapNode = trapdoors->first; trapNode != nullptr; trapNode = trapNode->next )
 							{
-								entity->yaw += PI * (rand() % 2) - PI / 2;
-								if ( entity->yaw >= PI * 2 )
+								Entity* trapEntity = (Entity*)trapNode->element;
+								if ( trapEntity && trapEntity->sprite == 252 && trapEntity->z <= -10 )
 								{
-									entity->yaw -= PI * 2;
-								}
-								else if ( entity->yaw < 0 )
-								{
-									entity->yaw += PI * 2;
+									foundTrapdoor = true;
+									break;
 								}
 							}
-							entity->behavior = &actBoulder;
-							entity->flags[UPDATENEEDED] = true;
-							entity->flags[PASSABLE] = true;
+							if ( foundTrapdoor )
+							{
+								Entity* entity = newEntity(245, 1, map.entities, nullptr); // boulder
+								entity->parent = my->getUID();
+								entity->x = (x << 4) + 8;
+								entity->y = (y << 4) + 8;
+								entity->z = -64;
+								entity->yaw = c * (PI / 2.f);
+								entity->sizex = 7;
+								entity->sizey = 7;
+								if ( checkObstacle(entity->x + cos(entity->yaw) * 16, entity->y + sin(entity->yaw) * 16, entity, NULL) )
+								{
+									entity->yaw += PI * (rand() % 2) - PI / 2;
+									if ( entity->yaw >= PI * 2 )
+									{
+										entity->yaw -= PI * 2;
+									}
+									else if ( entity->yaw < 0 )
+									{
+										entity->yaw += PI * 2;
+									}
+								}
+								entity->behavior = &actBoulder;
+								entity->flags[UPDATENEEDED] = true;
+								entity->flags[PASSABLE] = true;
+							}
 						}
 					}
 				}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -644,6 +644,11 @@ Entity* findEntityInLine( Entity* my, real_t x1, real_t y1, real_t angle, int en
 	std::vector<list_t*> entLists; // stores the possible entities to look through depending on the quadrant.
 	// start search from 1 tile behind facing direction in x/y position, extending to the edge of the map in the facing direction.
 
+	if ( multiplayer == CLIENT )
+	{
+		entLists.push_back(map.entities); // default to old map.entities if client (if they ever call this function...)
+	}
+
 	if ( angle >= PI / 2 && angle < PI ) // -x, +y
 	{
 		quadrant = 1;
@@ -651,11 +656,14 @@ Entity* findEntityInLine( Entity* my, real_t x1, real_t y1, real_t angle, int en
 			0,	std::min(static_cast<int>(map.width) - 1, originx + 1),
 			std::max(0, originy - 1), map.height - 1);*/
 
-		for ( int ix = std::min(static_cast<int>(map.width) - 1, originx + 1); ix >= 0; --ix )
+		if ( multiplayer != CLIENT )
 		{
-			for ( int iy = std::max(0, originy - 1); iy < map.height; ++iy )
+			for ( int ix = std::min(static_cast<int>(map.width) - 1, originx + 1); ix >= 0; --ix )
 			{
-				entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				for ( int iy = std::max(0, originy - 1); iy < map.height; ++iy )
+				{
+					entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				}
 			}
 		}
 	}
@@ -666,11 +674,14 @@ Entity* findEntityInLine( Entity* my, real_t x1, real_t y1, real_t angle, int en
 			std::max(0, originx - 1), map.width - 1,
 			std::max(0, originy - 1), map.height - 1);*/
 
-		for ( int ix = std::max(0, originx - 1); ix < map.width; ++ix )
+		if ( multiplayer != CLIENT )
 		{
-			for ( int iy = std::max(0, originy - 1); iy < map.height; ++iy )
+			for ( int ix = std::max(0, originx - 1); ix < map.width; ++ix )
 			{
-				entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				for ( int iy = std::max(0, originy - 1); iy < map.height; ++iy )
+				{
+					entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				}
 			}
 		}
 	}
@@ -681,11 +692,14 @@ Entity* findEntityInLine( Entity* my, real_t x1, real_t y1, real_t angle, int en
 			std::max(0, originx - 1), map.width - 1,
 			0, std::min(static_cast<int>(map.height) - 1, originy + 1));*/
 
-		for ( int ix = std::max(0, originx - 1); ix < map.width; ++ix )
+		if ( multiplayer != CLIENT )
 		{
-			for ( int iy = std::min(static_cast<int>(map.height) - 1, originy + 1); iy >= 0; --iy )
+			for ( int ix = std::max(0, originx - 1); ix < map.width; ++ix )
 			{
-				entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				for ( int iy = std::min(static_cast<int>(map.height) - 1, originy + 1); iy >= 0; --iy )
+				{
+					entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				}
 			}
 		}
 	}
@@ -696,11 +710,14 @@ Entity* findEntityInLine( Entity* my, real_t x1, real_t y1, real_t angle, int en
 			0, std::min(static_cast<int>(map.width) - 1, originx + 1),
 			0, std::min(static_cast<int>(map.height) - 1, originy + 1));*/
 
-		for ( int ix = std::min(static_cast<int>(map.width) - 1, originx + 1); ix >= 0; --ix )
+		if ( multiplayer != CLIENT )
 		{
-			for ( int iy = std::min(static_cast<int>(map.height) - 1, originy + 1); iy >= 0; --iy )
+			for ( int ix = std::min(static_cast<int>(map.width) - 1, originx + 1); ix >= 0; --ix )
 			{
-				entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				for ( int iy = std::min(static_cast<int>(map.height) - 1, originy + 1); iy >= 0; --iy )
+				{
+					entLists.push_back(&TileEntityList.gridEntities[ix][iy]);
+				}
 			}
 		}
 	}

--- a/src/files.cpp
+++ b/src/files.cpp
@@ -1393,7 +1393,7 @@ out_input_file:
 std::list<std::string> directoryContents(const char* directory, bool includeSubdirectory, bool includeFiles)
 {
 	std::list<std::string> list;
-	char fullPath[1024];
+	char fullPath[PATH_MAX];
 	completePath(fullPath, directory);
 	DIR* dir = opendir(fullPath);
 	struct dirent* entry = NULL;
@@ -1405,7 +1405,7 @@ std::list<std::string> directoryContents(const char* directory, bool includeSubd
 	}
 
 	struct stat cur;
-	char curPath[1024];
+	char curPath[PATH_MAX];
 	while ((entry = readdir(dir)) != NULL)
 	{
 		strcpy(curPath, fullPath);
@@ -1605,7 +1605,6 @@ std::list<std::string> physfsGetFileNamesInDirectory(const char* dir)
 		return filenames;
 	}
 	char **i;
-	char buf[1024];
 	std::string file;
 	for ( i = rc; *i != NULL; i++ )
 	{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2002,6 +2002,54 @@ void handleEvents(void)
 					mouseyrel = 0;
 				}
 				break;
+			case SDL_WINDOWEVENT:
+				if ( event.window.event == SDL_WINDOWEVENT_FOCUS_LOST && mute_audio_on_focus_lost )
+				{
+#ifdef USE_FMOD
+					if ( music_group )
+					{
+						FMOD_ChannelGroup_SetVolume(music_group, 0.f);
+					}
+					if ( sound_group )
+					{
+						FMOD_ChannelGroup_SetVolume(sound_group, 0.f);
+					}
+#endif // USE_FMOD
+#ifdef USE_OPENAL
+					if ( music_group )
+					{
+						OPENAL_ChannelGroup_SetVolume(music_group, 0.f);
+					}
+					if ( sound_group )
+					{
+						OPENAL_ChannelGroup_SetVolume(sound_group, 0.f);
+					}
+#endif
+				}
+				else if ( event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED )
+				{
+#ifdef USE_FMOD
+					if ( music_group )
+					{
+						FMOD_ChannelGroup_SetVolume(music_group, musvolume / 128.f);
+					}
+					if ( sound_group )
+					{
+						FMOD_ChannelGroup_SetVolume(sound_group, sfxvolume / 128.f);
+					}
+#endif // USE_FMOD
+#ifdef USE_OPENAL
+					if ( music_group )
+					{
+						OPENAL_ChannelGroup_SetVolume(music_group, musvolume / 128.f);
+					}
+					if ( sound_group )
+					{
+						OPENAL_ChannelGroup_SetVolume(sound_group, sfxvolume / 128.f);
+					}
+#endif
+				}
+				break;
 				/*case SDL_CONTROLLERAXISMOTION:
 					printlog("Controller axis motion detected.\n");
 					//if (event.caxis.which == 0) //TODO: Multi-controller support.

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -19,7 +19,7 @@
 #endif
 
 // REMEMBER TO CHANGE THIS WITH EVERY NEW OFFICIAL VERSION!!!
-#define VERSION "v3.2.1"
+#define VERSION "v3.2.2"
 #define GAME_CODE
 
 //#define MAX_FPS_LIMIT 60 //TODO: Make this configurable.

--- a/src/interface/consolecommand.cpp
+++ b/src/interface/consolecommand.cpp
@@ -2056,18 +2056,6 @@ void consoleCommand(char* command_str)
 		monsterGlobalAttackTimeMultiplier = speed;
 		messagePlayer(clientnum, "Changed attack speed multiplier to %d.", speed);
 	}
-	else if ( !strncmp(command_str, "/brawlermode", 12) )
-	{
-		achievementBrawlerMode = !achievementBrawlerMode;
-		if ( achievementBrawlerMode )
-		{
-			messagePlayer(clientnum, language[2995]);
-		}
-		else
-		{
-			messagePlayer(clientnum, language[2996]);
-		}
-	}
 	else if ( !strncmp(command_str, "/loadmod ", 9) )
 	{
 		std::string cmd = command_str;
@@ -2217,6 +2205,22 @@ void consoleCommand(char* command_str)
 			else
 			{
 				players[clientnum]->entity->setEffect(effect, true, 500, true);
+			}
+		}
+		else if ( !strncmp(command_str, "/brawlermode", 12) )
+		{
+			achievementBrawlerMode = !achievementBrawlerMode;
+			if ( achievementBrawlerMode && conductGameChallenges[CONDUCT_BRAWLER] )
+			{
+				messagePlayer(clientnum, language[2995]);
+			}
+			else if ( achievementBrawlerMode && !conductGameChallenges[CONDUCT_BRAWLER] )
+			{
+				messagePlayer(clientnum, language[2998]);
+			}
+			else if ( !achievementBrawlerMode )
+			{
+				messagePlayer(clientnum, language[2996]);
 			}
 		}
 		else

--- a/src/interface/consolecommand.cpp
+++ b/src/interface/consolecommand.cpp
@@ -515,47 +515,17 @@ void consoleCommand(char* command_str)
 		else if ( strstr(command_str, "IN_TURNL") )
 		{
 			impulses[IN_TURNL] = atoi(&command_str[6]);
-			if ( impulses[IN_FOLLOWERMENU_LASTCMD] == impulses[IN_TURNL] )
-			{
-				// reset to default arrow key to avoid overlapping keybinds on first launch.
-				// due to legacy keybind, now we have useful things to assign to q,e,z,c
-				impulses[IN_TURNL] = 80;
-				printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU_LASTCMD. Automatically rebound IN_TURNL: %d (Left arrow key)\n", impulses[IN_TURNL]);
-			}
-			else
-			{
-				printlog("Bound IN_TURNL: %d\n", atoi(&command_str[6]));
-			}
+			printlog("Bound IN_TURNL: %d\n", atoi(&command_str[6]));
 		}
 		else if ( strstr(command_str, "IN_TURNR") )
 		{
 			impulses[IN_TURNR] = atoi(&command_str[6]);
-			if ( impulses[IN_FOLLOWERMENU_CYCLENEXT] == impulses[IN_TURNR] )
-			{
-				// reset to default arrow key to avoid overlapping keybinds on first launch.
-				// due to legacy keybind, now we have useful things to assign to q,e,z,c
-				impulses[IN_TURNR] = 79;
-				printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU_CYCLENEXT. Automatically rebound IN_TURNR: %d (Right arrow key)\n", impulses[IN_TURNR]);
-			}
-			else
-			{
-				printlog("Bound IN_TURNR: %d\n", atoi(&command_str[6]));
-			}
+			printlog("Bound IN_TURNR: %d\n", atoi(&command_str[6]));
 		}
 		else if ( strstr(command_str, "IN_UP") )
 		{
 			impulses[IN_UP] = atoi(&command_str[6]);
-			if ( impulses[IN_FOLLOWERMENU] == impulses[IN_UP] )
-			{
-				// reset to default arrow key to avoid overlapping keybinds on first launch.
-				// due to legacy keybind, now we have useful things to assign to q,e,z,c
-				impulses[IN_UP] = 82;
-				printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU. Automatically rebound IN_UP: %d (Up arrow key)\n", impulses[IN_UP]);
-			}
-			else
-			{
-				printlog("Bound IN_UP: %d\n", atoi(&command_str[6]));
-			}
+			printlog("Bound IN_UP: %d\n", atoi(&command_str[6]));
 		}
 		else if ( strstr(command_str, "IN_DOWN") )
 		{

--- a/src/interface/consolecommand.cpp
+++ b/src/interface/consolecommand.cpp
@@ -2138,7 +2138,11 @@ void consoleCommand(char* command_str)
 
 	if ( invalidcommand ) // starting new if else block to get around compiler >128 statement limit.
 	{
-		if ( !strncmp(command_str, "/minimaptransparencyfg", 22) )
+		if ( !strncmp(command_str, "/muteaudiofocuslost", 19) )
+		{
+			mute_audio_on_focus_lost = (mute_audio_on_focus_lost == false);
+		}
+		else if ( !strncmp(command_str, "/minimaptransparencyfg", 22) )
 		{
 			minimapTransparencyForeground = atoi(&command_str[23]);
 			minimapTransparencyForeground = std::min(std::max<int>(0, minimapTransparencyForeground), 100);

--- a/src/interface/consolecommand.cpp
+++ b/src/interface/consolecommand.cpp
@@ -2174,6 +2174,10 @@ void consoleCommand(char* command_str)
 		{
 			hide_playertags = !hide_playertags;
 		}
+		else if ( !strncmp(command_str, "/showskillvalues", 16) )
+		{
+			show_skill_values = !show_skill_values;
+		}
 		else if ( !strncmp(command_str, "/disablenetworkmultithreading", 29) )
 		{
 			disableMultithreadedSteamNetworking = !disableMultithreadedSteamNetworking;

--- a/src/interface/drawstatus.cpp
+++ b/src/interface/drawstatus.cpp
@@ -230,10 +230,10 @@ void updateEnemyBar(Entity* source, Entity* target, char* name, Sint32 hp, Sint3
 			{
 				enemy_oldhp = stats->OLDHP;
 			}
-			else
-			{
-				enemy_oldhp = enemy_hp; // chairs/tables and things.
-			}
+		}
+		if ( !stats )
+		{
+			enemy_oldhp = hp; // chairs/tables and things.
 		}
 		enemy_lastuid = target->getUID();
 	}

--- a/src/interface/drawstatus.cpp
+++ b/src/interface/drawstatus.cpp
@@ -308,25 +308,6 @@ void drawStatus()
 		drawImageScaled(status_bmp, NULL, &pos);
 	}
 
-	// hunger icon
-	if ( stats[clientnum]->HUNGER <= 250 && (ticks % 50) - (ticks % 25) )
-	{
-		pos.x = 128;
-		pos.y = yres - 160;
-		pos.w = 64;
-		pos.h = 64;
-		drawImageScaled(hunger_bmp, NULL, &pos);
-	}
-
-	if ( minotaurlevel && (ticks % 50) - (ticks % 25) )
-	{
-		pos.x = 128;
-		pos.y = yres - 160 + 64 + 2;
-		pos.w = 64;
-		pos.h = 64;
-		drawImageScaled(minotaur_bmp, nullptr, &pos);
-	}
-
 	// enemy health
 	if ( ticks - enemy_timer < 120 && enemy_timer )
 	{
@@ -653,6 +634,26 @@ void drawStatus()
 		pos.x += uiscale_playerbars * 2;
 	}
 	printTextFormatted(font12x12_bmp, pos.x + 16 * uiscale_playerbars - strlen(tempstr) * 6, yres - (playerStatusBarHeight / 2 + 8), tempstr);
+
+	// hunger icon
+	if ( stats[clientnum]->HUNGER <= 250 && (ticks % 50) - (ticks % 25) )
+	{
+		pos.x = pos.x + playerStatusBarWidth + 10; // was pos.x = 128;
+		pos.y = yres - 160;
+		pos.w = 64;
+		pos.h = 64;
+		drawImageScaled(hunger_bmp, NULL, &pos);
+	}
+	// minotaur icon
+	if ( minotaurlevel && (ticks % 50) - (ticks % 25) )
+	{
+		//pos.x = 128;
+		pos.y = yres - 160 + 64 + 2;
+		pos.w = 64;
+		pos.h = 64;
+		drawImageScaled(minotaur_bmp, nullptr, &pos);
+	}
+
 
 	// PLAYER MAGIC BAR
 	// Display the Magic bar border

--- a/src/interface/interface.cpp
+++ b/src/interface/interface.cpp
@@ -1059,6 +1059,10 @@ int saveConfig(char* filename)
 	{
 		fprintf(fp, "/muteping\n");
 	}
+	if ( mute_audio_on_focus_lost )
+	{
+		fprintf(fp, "/muteaudiofocuslost\n");
+	}
 	if (colorblind)
 	{
 		fprintf(fp, "/colorblind\n");

--- a/src/interface/interface.cpp
+++ b/src/interface/interface.cpp
@@ -750,6 +750,10 @@ void defaultConfig()
 	consoleCommand("/bind 21 IN_AUTOSORT");
 	consoleCommand("/bind 27 IN_MINIMAPSCALE");
 	consoleCommand("/bind 15 IN_TOGGLECHATLOG");
+	consoleCommand("/bind 6 IN_FOLLOWERMENU");
+	consoleCommand("/bind 20 IN_FOLLOWERMENU_LASTCMD");
+	consoleCommand("/bind 8 IN_FOLLOWERMENU_CYCLENEXT");
+
 	consoleCommand("/joybind 307 INJOY_STATUS");
 	consoleCommand("/joybind 399 INJOY_SPELL_LIST"); //SCANCODE_UNASSIGNED_BINDING
 	consoleCommand("/joybind 311 INJOY_GAME_CAST_SPELL");
@@ -937,6 +941,32 @@ int loadConfig(char* filename)
 	{
 		free(filename);
 	}
+
+	if ( impulses[IN_FOLLOWERMENU_CYCLENEXT] == impulses[IN_TURNR]
+		&& impulses[IN_TURNR] == 8 )
+	{
+		// reset to default arrow key to avoid overlapping keybinds on first launch.
+		// due to legacy keybind, now we have useful things to assign to q,e,z,c
+		impulses[IN_TURNR] = 79;
+		printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU_CYCLENEXT. Automatically rebound IN_TURNR: %d (Right arrow key)\n", impulses[IN_TURNR]);
+	}
+	if ( impulses[IN_FOLLOWERMENU] == impulses[IN_UP]
+		&& impulses[IN_UP] == 6 )
+	{
+		// reset to default arrow key to avoid overlapping keybinds on first launch.
+		// due to legacy keybind, now we have useful things to assign to q,e,z,c
+		impulses[IN_UP] = 82;
+		printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU_CYCLENEXT. Automatically rebound IN_TURNR: %d (Right arrow key)\n", impulses[IN_TURNR]);
+	}
+	if ( impulses[IN_FOLLOWERMENU_LASTCMD] == impulses[IN_TURNL]
+		&& impulses[IN_TURNL] == 20 )
+	{
+		// reset to default arrow key to avoid overlapping keybinds on first launch.
+		// due to legacy keybind, now we have useful things to assign to q,e,z,c
+		impulses[IN_TURNL] = 80;
+		printlog("Legacy keys detected, conflict with IN_FOLLOWERMENU_CYCLENEXT. Automatically rebound IN_TURNR: %d (Right arrow key)\n", impulses[IN_TURNR]);
+	}
+
 	return 0;
 }
 

--- a/src/interface/interface.cpp
+++ b/src/interface/interface.cpp
@@ -157,6 +157,7 @@ bool lock_right_sidebar = false;
 bool show_game_timer_always = false;
 bool hide_statusbar = false;
 bool hide_playertags = false;
+bool show_skill_values = false;
 real_t uiscale_chatlog = 1.f;
 real_t uiscale_playerbars = 1.f;
 real_t uiscale_hotbar = 1.f;
@@ -1210,6 +1211,10 @@ int saveConfig(char* filename)
 	if ( hide_playertags )
 	{
 		fprintf(fp, "/hideplayertags\n");
+	}
+	if ( show_skill_values )
+	{
+		fprintf(fp, "/showskillvalues\n");
 	}
 	if ( disableMultithreadedSteamNetworking )
 	{

--- a/src/interface/interface.hpp
+++ b/src/interface/interface.hpp
@@ -390,6 +390,8 @@ extern bool show_game_timer_always;
 
 extern bool hide_playertags;
 
+extern bool show_skill_values;
+
 const char* getInputName(Uint32 scancode);
 Sint8* inputPressed(Uint32 scancode);
 

--- a/src/interface/updatecharactersheet.cpp
+++ b/src/interface/updatecharactersheet.cpp
@@ -19,6 +19,7 @@
 #include "interface.hpp"
 #include "../sound.hpp"
 #include "../magic/magic.hpp"
+#include "../menu.hpp"
 
 void statsHoverText(Stat* tmpStat);
 
@@ -408,7 +409,11 @@ void drawSkillsSheet()
 			color = uint32ColorWhite(*mainsurface);
 		}
 
-		if ( stats[clientnum]->PROFICIENCIES[i] == 0 )
+		if ( show_skill_values )
+		{
+			ttfPrintTextFormattedColor(fontSkill, pos.x + 4, pos.y, color, "%15d / 100", stats[clientnum]->PROFICIENCIES[i]);
+		}
+		else if ( stats[clientnum]->PROFICIENCIES[i] == 0 )
 		{
 			ttfPrintTextFormattedColor(fontSkill, pos.x + 4, pos.y, color, language[363]);
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,7 @@ bool* vismap = nullptr;
 bool mode3d = false;
 bool verticalSync = false;
 bool minimapPingMute = false;
+bool mute_audio_on_focus_lost = false;
 int minimapTransparencyForeground = 0;
 int minimapTransparencyBackground = 0;
 int minimapScale = 4;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -483,6 +483,7 @@ extern int rscale;
 extern real_t vidgamma;
 extern bool verticalSync;
 extern bool minimapPingMute;
+extern bool mute_audio_on_focus_lost;
 extern int minimapTransparencyForeground;
 extern int minimapTransparencyBackground;
 extern int minimapScale;

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -2511,6 +2511,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(2, 0, map->entities, nullptr); //Door frame entity.
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("19 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 8;
 				childEntity->sizey = 1;
@@ -2523,6 +2524,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x - 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("20 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -2532,6 +2534,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x + 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("21 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -3497,6 +3500,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(186, 0, map->entities, nullptr); //Switch entity.
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("22 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->z = 8;
 				childEntity->focalz = -4.5;
@@ -3535,6 +3539,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(186, 0, map->entities, nullptr); //Gate entity.
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("23 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 8;
 				childEntity->sizey = 1;
@@ -3550,6 +3555,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x - 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("24 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -3560,6 +3566,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x + 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("25 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -3576,6 +3583,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(186, 0, map->entities, nullptr); //Gate entity.
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("26 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 1;
 				childEntity->sizey = 8;
@@ -3590,6 +3598,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x;
 				childEntity->y = entity->y - 7;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("27 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -3600,6 +3609,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x;
 				childEntity->y = entity->y + 7;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("28 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -3646,6 +3656,7 @@ void assignActions(map_t* map)
 					childEntity->x = entity->x;
 					childEntity->y = entity->y - 3;
 				}
+				TileEntityList.addEntity(*childEntity);
 				//printlog("29 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->z = entity->z - 2.75;
 				childEntity->focalx = 3;
@@ -3814,6 +3825,7 @@ void assignActions(map_t* map)
 							{
 								childEntity->z = -10.99;
 							}
+							TileEntityList.addEntity(*childEntity);
 							entity->boulderTrapRocksToSpawn |= (1 << c); // add this location to spawn a boulder below the trapdoor model.
 						}
 					}
@@ -3931,6 +3943,7 @@ void assignActions(map_t* map)
 					childEntity = newEntity(8, 1, map->entities, nullptr);
 					childEntity->x = entity->x - 8;
 					childEntity->y = entity->y - 8;
+					TileEntityList.addEntity(*childEntity);
 					//printlog("31 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 					childEntity->z = 0;
 					childEntity->itemNotMoving = 1; // so the item retains its position
@@ -3959,6 +3972,7 @@ void assignActions(map_t* map)
 						}
 						childEntity->x -= cos(childEntity->yaw) * 7;
 						childEntity->y -= sin(childEntity->yaw) * 7;
+						TileEntityList.addEntity(*childEntity);
 					}
 				}
 				break;
@@ -4031,6 +4045,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(283, 0, map->entities, nullptr);
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("33 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->z = entity->z - 7.75 - 0.01;
 				childEntity->flags[PASSABLE] = true;
@@ -4199,6 +4214,7 @@ void assignActions(map_t* map)
 						{
 							childEntity->z = -10.99;
 						}
+						TileEntityList.addEntity(*childEntity);
 					}
 				}
 				break;
@@ -4238,6 +4254,7 @@ void assignActions(map_t* map)
 						{
 							childEntity->z = -10.99;
 						}
+						TileEntityList.addEntity(*childEntity);
 					}
 				}
 				break;
@@ -4277,6 +4294,7 @@ void assignActions(map_t* map)
 						{
 							childEntity->z = -10.99;
 						}
+						TileEntityList.addEntity(*childEntity);
 					}
 				}
 				break;
@@ -4316,6 +4334,7 @@ void assignActions(map_t* map)
 						{
 							childEntity->z = -10.99;
 						}
+						TileEntityList.addEntity(*childEntity);
 					}
 				}
 				break;
@@ -4361,6 +4380,7 @@ void assignActions(map_t* map)
 				childEntity->sizey = 4;
 				childEntity->behavior = &actPowerCrystal;
 				childEntity->flags[PASSABLE] = true;
+				TileEntityList.addEntity(*childEntity);
 
 				node_t* tempNode = list_AddNodeLast(&entity->children);
 				tempNode->element = childEntity; // add the node to the children list.
@@ -4481,6 +4501,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(186, 0, map->entities, nullptr);
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("23 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 8;
 				childEntity->sizey = 1;
@@ -4496,6 +4517,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x - 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("24 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -4506,6 +4528,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x + 7;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("25 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -4522,6 +4545,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(186, 0, map->entities, nullptr);
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("26 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 1;
 				childEntity->gateInverted = 1; // inverted.
@@ -4536,6 +4560,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x;
 				childEntity->y = entity->y - 7;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("27 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -4546,6 +4571,7 @@ void assignActions(map_t* map)
 				childEntity->flags[BLOCKSIGHT] = true;
 				childEntity->x = entity->x;
 				childEntity->y = entity->y + 7;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("28 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -4563,6 +4589,7 @@ void assignActions(map_t* map)
 				childEntity = newEntity(586, 0, map->entities, nullptr);
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				//printlog("22 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 				childEntity->z = 8;
 				childEntity->leverTimerTicks = std::max(entity->leverTimerTicks, 1) * TICKS_PER_SECOND; // convert seconds to ticks from editor, make sure not less than 1
@@ -4606,6 +4633,7 @@ void assignActions(map_t* map)
 				childEntity->behavior = &actPedestalOrb;
 				childEntity->x = entity->x;
 				childEntity->y = entity->y;
+				TileEntityList.addEntity(*childEntity);
 				childEntity->z = -2;
 				childEntity->sizex = 2;
 				childEntity->sizey = 2;
@@ -4751,6 +4779,7 @@ void assignActions(map_t* map)
 						{
 							childEntity->z = -6.99;
 						}
+						TileEntityList.addEntity(*childEntity);
 						node_t* tempNode = list_AddNodeLast(&entity->children);
 						tempNode->element = childEntity; // add the node to the children list.
 						tempNode->deconstructor = &emptyDeconstructor;
@@ -4761,6 +4790,7 @@ void assignActions(map_t* map)
 						childEntity->x = entity->x;
 						childEntity->y = entity->y;
 						childEntity->z = 8.24;
+						TileEntityList.addEntity(*childEntity);
 						//printlog("30 Generated entity. Sprite: %d Uid: %d X: %.2f Y: %.2f\n",childEntity->sprite,childEntity->getUID(),childEntity->x,childEntity->y);
 						childEntity->flags[PASSABLE] = true;
 						tempNode = list_AddNodeLast(&entity->children);
@@ -4919,6 +4949,7 @@ void assignActions(map_t* map)
 				childEntity->behavior = &actPistonCam;
 				childEntity->pistonCamRotateSpeed = 0.2;
 				childEntity->flags[UNCLICKABLE] = true;
+				TileEntityList.addEntity(*childEntity);
 				/*if ( multiplayer != CLIENT )
 				{
 					entity_uids--;
@@ -4931,6 +4962,7 @@ void assignActions(map_t* map)
 				childEntity->behavior = &actPistonCam;
 				childEntity->pistonCamRotateSpeed = -0.2;
 				childEntity->flags[UNCLICKABLE] = true;
+				TileEntityList.addEntity(*childEntity);
 				/*if ( multiplayer != CLIENT )
 				{
 					entity_uids--;
@@ -5043,35 +5075,60 @@ void assignActions(map_t* map)
 		}
 	}
 
-	for ( node = map->entities->first; node != nullptr; node = node->next )
+	for ( node = map->entities->first; node != nullptr; )
 	{
-		Entity* itemEnt = (Entity*)node->element;
-		if ( itemEnt && itemEnt->behavior == &actItem )
+		node = node->next;
+		Entity* postProcessEntity = (Entity*)node->element;
+		if ( postProcessEntity )
 		{
-			// see if there's any platforms to set items upon.
-			for ( node_t* tmpnode = map->entities->first; tmpnode != nullptr; tmpnode = tmpnode->next )
+			if ( postProcessEntity->behavior == &actItem )
 			{
-				Entity* tmpentity = (Entity*)tmpnode->element;
-				if ( (tmpentity->behavior == &actFurniture
-						&& (tmpentity->x == itemEnt->x) && (tmpentity->y == itemEnt->y)
-					) )
+				// see if there's any platforms to set items upon.
+				for ( node_t* tmpnode = map->entities->first; tmpnode != nullptr; tmpnode = tmpnode->next )
 				{
-					if ( itemEnt->z > 4 )
+					Entity* tmpentity = (Entity*)tmpnode->element;
+					if ( (tmpentity->behavior == &actFurniture
+							&& (tmpentity->x == postProcessEntity->x) && (tmpentity->y == postProcessEntity->y)
+						) )
 					{
-						if ( tmpentity->sprite == 271 )
+						if ( postProcessEntity->z > 4 )
 						{
-							// is table
-							itemEnt->z -= 6;
-							tmpentity->parent = itemEnt->getUID();
+							if ( tmpentity->sprite == 271 )
+							{
+								// is table
+								postProcessEntity->z -= 6;
+								tmpentity->parent = postProcessEntity->getUID();
+							}
+							else if ( tmpentity->sprite == 630 )
+							{
+								// is podium
+								postProcessEntity->z -= 6;
+								tmpentity->parent = postProcessEntity->getUID();
+							}
 						}
-						else if ( tmpentity->sprite == 630 )
+						break;
+					}
+				}
+			}
+			else if ( postProcessEntity->sprite == 252 && postProcessEntity->z <= -10 )
+			{
+				// trapdoor for boulder traps.
+				int findx = static_cast<int>(postProcessEntity->x) >> 4;
+				int findy = static_cast<int>(postProcessEntity->y) >> 4;
+				list_t* entitiesOnTile = TileEntityList.getTileList(findx, findy);
+				for ( node_t* tmpnode = entitiesOnTile->first; tmpnode != nullptr; tmpnode = tmpnode->next )
+				{
+					Entity* tmpentity = (Entity*)tmpnode->element;
+					if ( tmpentity && tmpentity != postProcessEntity )
+					{
+						if ( tmpentity->behavior != &actMonster
+							&& !tmpentity->flags[PASSABLE] )
 						{
-							// is podium
-							itemEnt->z -= 6;
-							tmpentity->parent = itemEnt->getUID();
+							// remove the trapdoor since we've spawned over a gate, chest, door etc.
+							list_RemoveNode(postProcessEntity->mynode);
+							break;
 						}
 					}
-					break;
 				}
 			}
 		}

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -5077,8 +5077,8 @@ void assignActions(map_t* map)
 
 	for ( node = map->entities->first; node != nullptr; )
 	{
-		node = node->next;
 		Entity* postProcessEntity = (Entity*)node->element;
+		node = node->next;
 		if ( postProcessEntity )
 		{
 			if ( postProcessEntity->behavior == &actItem )
@@ -5122,7 +5122,8 @@ void assignActions(map_t* map)
 					if ( tmpentity && tmpentity != postProcessEntity )
 					{
 						if ( tmpentity->behavior != &actMonster
-							&& !tmpentity->flags[PASSABLE] )
+							&& !tmpentity->flags[PASSABLE]
+							&& tmpentity->behavior != &actFurniture )
 						{
 							// remove the trapdoor since we've spawned over a gate, chest, door etc.
 							list_RemoveNode(postProcessEntity->mynode);

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -3156,6 +3156,7 @@ void handleMainMenu(bool mode)
 				tooltip_box.y = omousey + 8;
 				tooltip_box.h = TTF12_HEIGHT + 8;
 
+#ifdef STEAMWORKS
 				// networking hover text and mouse selection
 				current_y = networking_options_start_y;
 
@@ -3171,6 +3172,7 @@ void handleMainMenu(bool mode)
 						settings_disableMultithreadedSteamNetworking = (settings_disableMultithreadedSteamNetworking == false);
 					}
 				}
+#endif // STEAMWORKS
 
 				current_y = options_start_y;
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -198,6 +198,7 @@ real_t settings_uiscale_chatlog = 1.f;
 real_t settings_uiscale_inventory = 1.f;
 bool settings_hide_statusbar = false;
 bool settings_hide_playertags = false;
+bool settings_show_skill_values = false;
 bool settings_disableMultithreadedSteamNetworking = false;
 Sint32 oslidery = 0;
 
@@ -2300,64 +2301,77 @@ void handleMainMenu(bool mode)
 			doSlider(subx1 + 498, suby1 + 222 + 24, 10, 0, 100, 1, (int*)(&settings_minimap_transparency_background));
 
 			// UI options
-			ttfPrintText(ttf12, subx1 + 498, suby1 + 282, language[3034]);
+			ttfPrintText(ttf12, subx1 + 498, suby1 + 276, language[3034]);
 
 			if ( settings_uiscale_charactersheet )
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 306, "[x] %s", language[3027]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 300, "[x] %s", language[3027]);
 			}
 			else
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 306, "[ ] %s", language[3027]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 300, "[ ] %s", language[3027]);
 			}
 			if ( settings_uiscale_skillspage )
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 330, "[x] %s", language[3028]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 324, "[x] %s", language[3028]);
 			}
 			else
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 330, "[ ] %s", language[3028]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 324, "[ ] %s", language[3028]);
 			}
 			if ( settings_hide_statusbar )
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 354, "[x] %s", language[3033]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 348, "[x] %s", language[3033]);
 			}
 			else
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 354, "[ ] %s", language[3033]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 348, "[ ] %s", language[3033]);
 			}
 			if ( settings_hide_playertags )
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 378, "[x] %s", language[3136]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 372, "[x] %s", language[3136]);
 			}
 			else
 			{
-				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 378, "[ ] %s", language[3136]);
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 372, "[ ] %s", language[3136]);
+			}
+			if ( settings_show_skill_values )
+			{
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 396, "[x] %s", language[3159]);
+			}
+			else
+			{
+				ttfPrintTextFormatted(ttf12, subx1 + 498, suby1 + 396, "[ ] %s", language[3159]);
 			}
 
 			if ( mousestatus[SDL_BUTTON_LEFT] )
 			{
 				if ( omousex >= subx1 + 498 && omousex < subx1 + 522 )
 				{
-					if ( omousey >= suby1 + 306 && omousey < suby1 + 306 + 12 )
+					if ( omousey >= suby1 + 300 && omousey < suby1 + 300 + 12 )
 					{
 						mousestatus[SDL_BUTTON_LEFT] = 0;
 						settings_uiscale_charactersheet = (settings_uiscale_charactersheet == 0);
 					}
-					else if ( omousey >= suby1 + 330 && omousey < suby1 + 330 + 12 )
+					else if ( omousey >= suby1 + 324 && omousey < suby1 + 324 + 12 )
 					{
 						mousestatus[SDL_BUTTON_LEFT] = 0;
 						settings_uiscale_skillspage = (settings_uiscale_skillspage == 0);
 					}
-					else if ( omousey >= suby1 + 354 && omousey < suby1 + 354 + 12 )
+					else if ( omousey >= suby1 + 348 && omousey < suby1 + 348 + 12 )
 					{
 						mousestatus[SDL_BUTTON_LEFT] = 0;
 						settings_hide_statusbar = (settings_hide_statusbar == 0);
 					}
-					else if ( omousey >= suby1 + 378 && omousey < suby1 + 378 + 12 )
+					else if ( omousey >= suby1 + 372 && omousey < suby1 + 372 + 12 )
 					{
 						mousestatus[SDL_BUTTON_LEFT] = 0;
 						settings_hide_playertags = (settings_hide_playertags == 0);
+					}
+					else if ( omousey >= suby1 + 396 && omousey < suby1 + 396 + 12 )
+					{
+						mousestatus[SDL_BUTTON_LEFT] = 0;
+						settings_show_skill_values = (settings_show_skill_values == 0);
 					}
 				}
 			}
@@ -4740,7 +4754,7 @@ void handleMainMenu(bool mode)
 #ifdef STEAMWORKS
 	if ( score_leaderboard_window != 0 && g_SteamLeaderboards )
 	{
-		int numEntriesToShow = 10;
+		int numEntriesToShow = 15;
 		int filenameMaxLength = 48;
 		int filename_padx = subx1 + 16;
 		int filename_pady = suby1 + 32;
@@ -4853,7 +4867,7 @@ void handleMainMenu(bool mode)
 			for ( int i = 0; i < numEntriesTotal; ++i )
 			{
 				filename_padx = subx1 + 16;
-				if ( i >= g_SteamLeaderboards->LeaderboardView.scrollIndex && i < numEntriesTotal + g_SteamLeaderboards->LeaderboardView.scrollIndex )
+				if ( i >= g_SteamLeaderboards->LeaderboardView.scrollIndex && i < numEntriesToShow + g_SteamLeaderboards->LeaderboardView.scrollIndex )
 				{
 					drawWindowFancy(filename_padx, filename_pady - 8, filename_padx2, filename_pady + filename_rowHeight);
 					SDL_Rect highlightEntry;
@@ -4897,7 +4911,7 @@ void handleMainMenu(bool mode)
 					filename_padx = filename_padx2 - (15 * TTF12_WIDTH + 16);
 					int text_x = filename_padx;
 					int text_y = filename_pady;
-					if ( savegameDrawClickableButton(filename_padx, filename_pady, 15 * TTF12_WIDTH + 8, TTF12_HEIGHT, 0) && score_leaderboard_window != 3 )
+					if ( drawClickableButton(filename_padx, filename_pady, 15 * TTF12_WIDTH + 8, TTF12_HEIGHT, 0) && score_leaderboard_window != 3 )
 					{
 						score_leaderboard_window = 3;
 						g_SteamLeaderboards->currentLeaderBoardIndex = i;
@@ -4924,8 +4938,8 @@ void handleMainMenu(bool mode)
 	{
 		if ( score_leaderboard_window == 3 )
 		{
-			drawWindowFancy(subx1 + 20, suby1 + 20, subx2 - 20, suby2 - 10);
-			if ( savegameDrawClickableButton(subx2 - 10 * TTF12_WIDTH - 8, suby1 + 20 + 8, 8 * TTF12_WIDTH, TTF12_HEIGHT, 0) )
+			drawWindowFancy(subx1 + 10, suby1 + 20, subx2 - 10, suby2 - 10);
+			if ( drawClickableButton(subx2 - 10 * TTF12_WIDTH - 3, suby1 + 20 + 8, 8 * TTF12_WIDTH, TTF12_HEIGHT, 0) )
 			{
 				score_leaderboard_window = 2;
 				for ( node = button_l.first; node != NULL; node = node->next )
@@ -4934,7 +4948,7 @@ void handleMainMenu(bool mode)
 					button->visible = 1;
 				}
 			}
-			ttfPrintTextFormatted(ttf12, subx2 - 10 * TTF12_WIDTH + 4, suby1 + 20 + 8, "close");
+			ttfPrintTextFormatted(ttf12, subx2 - 10 * TTF12_WIDTH + 9, suby1 + 20 + 8, "close");
 		}
 		// draw button label... shamelessly hacked together from "multiplayer scores toggle button" initialisation...
 		int toggleText_x = subx2 - 44 - strlen("show multiplayer") * 12;
@@ -5212,22 +5226,22 @@ void handleMainMenu(bool mode)
 					{
 						if ( x < KOBOLD )
 						{
-							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 180, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[111 + x]);
+							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 156, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[111 + x]);
 						}
 						else
 						{
-							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 180, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[2050 + (x - KOBOLD)]);
+							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 156, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[2050 + (x - KOBOLD)]);
 						}
 					}
 					else
 					{
 						if ( x < KOBOLD )
 						{
-							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 180, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[90 + x]);
+							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 156, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[90 + x]);
 						}
 						else
 						{
-							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 180, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[2000 + (x - KOBOLD)]);
+							ttfPrintTextFormatted(ttf12, subx1 + 456 + (y / 14) * 156, suby1 + 296 + (y % 14) * 12, "%d %s", kills[x], language[2000 + (x - KOBOLD)]);
 						}
 					}
 					y++;
@@ -5388,7 +5402,7 @@ void handleMainMenu(bool mode)
 				filename_padx = filename_padx2 - (13 * TTF12_WIDTH + 16);
 				int text_x = filename_padx;
 				int text_y = filename_pady + 10;
-				if ( savegameDrawClickableButton(filename_padx, filename_pady, 10 * TTF12_WIDTH + 8, TTF12_HEIGHT * 2 + 4, 0) )
+				if ( drawClickableButton(filename_padx, filename_pady, 10 * TTF12_WIDTH + 8, TTF12_HEIGHT * 2 + 4, 0) )
 				{
 					if ( std::get<1>(entry) == SINGLE )
 					{
@@ -5405,7 +5419,7 @@ void handleMainMenu(bool mode)
 
 				filename_padx = filename_padx2 - (2 * TTF12_WIDTH + 14);
 				text_x = filename_padx;
-				if ( savegameDrawClickableButton(filename_padx, filename_pady, 2 * TTF12_WIDTH + 8, TTF12_HEIGHT * 2 + 4, uint32ColorRed(*mainsurface)) )
+				if ( drawClickableButton(filename_padx, filename_pady, 2 * TTF12_WIDTH + 8, TTF12_HEIGHT * 2 + 4, uint32ColorRed(*mainsurface)) )
 				{
 					if ( std::get<1>(entry) == SINGLE )
 					{
@@ -8109,6 +8123,7 @@ void openSettingsWindow()
 	settings_uiscale_playerbars = uiscale_playerbars;
 	settings_hide_statusbar = hide_statusbar;
 	settings_hide_playertags = hide_playertags;
+	settings_show_skill_values = show_skill_values;
 	settings_disableMultithreadedSteamNetworking = disableMultithreadedSteamNetworking;
 	for (c = 0; c < NUMIMPULSES; c++)
 	{
@@ -9764,6 +9779,7 @@ void applySettings()
 	uiscale_playerbars = settings_uiscale_playerbars;
 	hide_statusbar = settings_hide_statusbar;
 	hide_playertags = settings_hide_playertags;
+	show_skill_values = settings_show_skill_values;
 	if ( net_handler && disableMultithreadedSteamNetworking != settings_disableMultithreadedSteamNetworking )
 	{
 		net_handler->toggleMultithreading(settings_disableMultithreadedSteamNetworking);
@@ -12491,7 +12507,7 @@ void gamemodsWindowClearVariables()
 	gamemods_subscribedItemsStatus = 0;
 }
 
-bool savegameDrawClickableButton(int padx, int pady, int padw, int padh, Uint32 btnColor)
+bool drawClickableButton(int padx, int pady, int padw, int padh, Uint32 btnColor)
 {
 	bool clicked = false;
 	if ( mouseInBounds(padx, padx + padw, pady - 4, pady + padh) )
@@ -12513,7 +12529,10 @@ bool savegameDrawClickableButton(int padx, int pady, int padw, int padh, Uint32 
 	pos.y = pady - 4;
 	pos.w = padw;
 	pos.h = padh + 4;
-	drawRect(&pos, btnColor, 64);
+	if ( btnColor != 0 )
+	{
+		drawRect(&pos, btnColor, 64);
+	}
 	return clicked;
 }
 #ifdef STEAMWORKS

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -163,7 +163,8 @@ bool settings_colorblind;
 bool settings_spawn_blood;
 bool settings_light_flicker;
 bool settings_vsync;
-bool settings_minimap_ping_mute;
+bool settings_minimap_ping_mute = false;
+bool settings_mute_audio_on_focus_lost = false;
 int settings_minimap_transparency_foreground = 0;
 int settings_minimap_transparency_background = 0;
 int settings_minimap_scale = 4;
@@ -2399,6 +2400,14 @@ void handleMainMenu(bool mode)
 			{
 				ttfPrintTextFormatted(ttf12, subx1 + 24, suby1 + 168, "[ ] %s", language[3012]);
 			}
+			if ( settings_mute_audio_on_focus_lost )
+			{
+				ttfPrintTextFormatted(ttf12, subx1 + 24, suby1 + 192, "[x] %s", language[3158]);
+			}
+			else
+			{
+				ttfPrintTextFormatted(ttf12, subx1 + 24, suby1 + 192, "[ ] %s", language[3158]);
+			}
 			if ( mousestatus[SDL_BUTTON_LEFT] )
 			{
 				if ( omousex >= subx1 + 30 && omousex < subx1 + 54 )
@@ -2407,6 +2416,11 @@ void handleMainMenu(bool mode)
 					{
 						mousestatus[SDL_BUTTON_LEFT] = 0;
 						settings_minimap_ping_mute = (settings_minimap_ping_mute == false);
+					}
+					else if ( omousey >= suby1 + 192 && omousey < suby1 + 192 + 12 )
+					{
+						mousestatus[SDL_BUTTON_LEFT] = 0;
+						settings_mute_audio_on_focus_lost = (settings_mute_audio_on_focus_lost == false);
 					}
 				}
 			}
@@ -8082,6 +8096,7 @@ void openSettingsWindow()
 	settings_sfxvolume = sfxvolume;
 	settings_musvolume = musvolume;
 	settings_minimap_ping_mute = minimapPingMute;
+	settings_mute_audio_on_focus_lost = mute_audio_on_focus_lost;
 	settings_minimap_transparency_foreground = minimapTransparencyForeground;
 	settings_minimap_transparency_background = minimapTransparencyBackground;
 	settings_minimap_scale = minimapScale;
@@ -9682,6 +9697,7 @@ void applySettings()
 	sfxvolume = settings_sfxvolume;
 	musvolume = settings_musvolume;
 	minimapPingMute = settings_minimap_ping_mute;
+	mute_audio_on_focus_lost = settings_mute_audio_on_focus_lost;
 
 #ifdef USE_FMOD
 	FMOD_ChannelGroup_SetVolume(music_group, musvolume / 128.f);

--- a/src/menu.hpp
+++ b/src/menu.hpp
@@ -156,7 +156,7 @@ bool gamemodsCheckFileIDInLoadedPaths(uint64 fileID);
 bool gamemodsIsClientLoadOrderMatchingHost(std::vector<std::string> serverModList);
 extern std::vector<std::pair<std::string, uint64>> gamemods_workshopLoadedFileIDMap;
 #endif // STEAMWORKS
-bool savegameDrawClickableButton(int padx, int pady, int padw, int padh, Uint32 btnColor);
+bool drawClickableButton(int padx, int pady, int padw, int padh, Uint32 btnColor);
 extern bool scoreDisplayMultiplayer;
 
 extern Sint32 slidery, slidersize, oslidery;
@@ -211,6 +211,7 @@ extern real_t settings_uiscale_chatlog;
 extern real_t settings_uiscale_inventory;
 extern bool settings_hide_statusbar;
 extern bool settings_hide_playertags;
+extern bool settings_show_skill_values;
 extern bool settings_disableMultithreadedSteamNetworking;
 
 static const int NUM_SETTINGS_TABS = 7;

--- a/src/menu.hpp
+++ b/src/menu.hpp
@@ -180,6 +180,7 @@ extern bool settings_spawn_blood;
 extern bool settings_light_flicker;
 extern bool settings_vsync;
 extern bool settings_minimap_ping_mute;
+extern bool settings_mute_audio_on_focus_lost;
 extern int settings_minimap_transparency_foreground;
 extern int settings_minimap_transparency_background;
 extern int settings_minimap_scale;


### PR DESCRIPTION
+ Add mute audio option if window focus lost
+ Add option to show skills as 20 / 100 instead of basic, adept, master etc.
* Fix steam leaderboard display for >15 entries
* Fix camera turn up/down/left/right getting rebound if set to defaults
* Fix boulders spawning ontop of chests/doors etc AGAIN. But this time for sure. Removes the trapdoors for the trap, and no trapdoor = no boulder. 
* Boulders now smoosh furniture instead of rolling through em.
* Show brawlermode status on enabling the command (let's you know if broken already)
* Fix furniture ghost hp displaying incorrectly sometimes when swapping targets
* minotaur/hunger icons move when resizing hp/mp bar scales.