### PR TITLE
* Fix power crystal electricity nodes not being added to tile entity …

### DIFF
--- a/src/actpowercrystal.cpp
+++ b/src/actpowercrystal.cpp
@@ -297,6 +297,8 @@ void Entity::powerCrystalCreateElectricityNodes()
 		node->deconstructor = &emptyDeconstructor;
 		node->size = sizeof(Entity*);
 
+		TileEntityList.addEntity(*entity); // make sure new nodes are added to the tile list to properly update neighbors.
+
 		this->crystalGeneratedElectricityNodes = 1;
 	}
 	


### PR DESCRIPTION
…list.

Power crystals weren't powering anything rendering the caves secret impassable. Introduced due to tile base electricity not adding the moved crystal nodes to the global list.