### PR TITLE
* Fix random crashing due to traps on borders of map

### DIFF
--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -3960,6 +3960,10 @@ returns a list of entities that are occupying the map tile specified at
 
 list_t* checkTileForEntity(int x, int y)
 {
+	if ( x < 0 || y < 0 || x > 255 || y > 255 )
+	{
+		return nullptr; // invalid grid reference!
+	}
 	return &TileEntityList.gridEntities[x][y];
 
 //	list_t* return_val = NULL;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -11041,7 +11041,6 @@ void buttonReplayLastCharacter(button_t* my)
 	if ( lastCreatedCharacterClass >= 0 )
 	{
 		playing_random_char = false;
-		charcreation_step = 5;
 		camera_charsheet_offsetyaw = (330) * PI / 180;
 		stats[0]->sex = static_cast<sex_t>(lastCreatedCharacterSex);
 		client_classes[0] = lastCreatedCharacterClass;
@@ -11049,6 +11048,8 @@ void buttonReplayLastCharacter(button_t* my)
 		initClass(0);
 		stats[0]->appearance = lastCreatedCharacterAppearance;
 		strcpy(stats[0]->name, lastname.c_str());
+		charcreation_step = 4; // set the step to 4, so clicking continue advances to 5 (single/multiplayer select)
+		buttonContinue(nullptr);
 	}
 }
 


### PR DESCRIPTION
* Fix using 'use last character' setting the savefile incorrectly and deleting the first slot always.