### PR TITLE
JSON file reader/writer

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -65,3 +65,20 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 
+
+
+RapidJSON License:
+
+Tencent is pleased to support the open source community by making RapidJSON available.
+
+Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+specific language governing permissions and limitations under the License.

--- a/VS.2015/Barony/Barony.vcxproj.filters
+++ b/VS.2015/Barony/Barony.vcxproj.filters
@@ -381,6 +381,9 @@
     <ClCompile Include="..\..\src\monster_sentrybot.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\json.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\book.hpp">
@@ -454,6 +457,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\cppfuncs.hpp">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\json.hpp">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,473 @@
+#include "main.hpp"
+#include "json.hpp"
+
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/error/en.h"
+
+const Uint32 BinaryFormatTag = 'spff';
+
+class JsonFileWriter : public FileInterface {
+public:
+
+	JsonFileWriter()
+	: buffer()
+	, writer(buffer)
+	{
+	}
+
+	static bool writeObject(FILE * file, const FileHelper::SerializationFunc& serialize) {
+		JsonFileWriter jfw;
+
+		jfw.beginObject();
+		serialize(&jfw);
+		jfw.endObject();
+
+		jfw.save(file);
+		return true;
+	}
+
+	virtual bool isReading() const override { return false; }
+
+	virtual void beginObject() override {
+		writer.StartObject();
+	}
+	virtual void endObject() override {
+		writer.EndObject();
+	}
+
+	virtual void beginArray(Uint32 & size) override {
+		writer.StartArray();
+	}
+	virtual void endArray() override {
+		writer.EndArray();
+	}
+
+	virtual void propertyName(const char * fieldName) override {
+		writer.Key(fieldName);
+	}
+
+	virtual void value(Uint32& value) override {
+		writer.Uint(value);
+	}
+	virtual void value(Sint32& value) override {
+		writer.Int(value);
+	}
+	virtual void value(float& value) override {
+		writer.Double(value);
+	}
+	virtual void value(double& value) override {
+		writer.Double(value);
+	}
+	virtual void value(bool& value) override {
+		writer.Bool(value);
+	}
+	virtual void value(std::string& value, Uint32 maxLength) override {
+		assert(maxLength == 0 || value.size() <= maxLength);
+		writer.String(value.c_str());
+	}
+
+private:
+
+	void save(FILE * file) {
+		buffer.Flush();
+		fputs(buffer.GetString(), file);
+	}
+
+	FILE * fp;
+	rapidjson::StringBuffer buffer;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer;
+};
+
+class JsonFileReader : public FileInterface {
+public:
+
+	static bool readObject(FILE * fp, const FileHelper::SerializationFunc & serialize) {
+		JsonFileReader jfr;
+
+		if (!jfr.readAllFileData(fp)) {
+			return false;
+		}
+
+		jfr.beginObject();
+		serialize(&jfr);
+		jfr.endObject();
+
+		return true;
+	}
+
+	virtual bool isReading() const override { return true; }
+
+	virtual void beginObject() override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsObject());
+		DocIterator di;
+		di.it = cv;
+		di.index = -1;
+		stack.push_back(di);
+	}
+
+	virtual void endObject() override {
+		stack.pop_back();
+	}
+
+	virtual void beginArray(Uint32 & size) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsArray());
+		DocIterator di;
+		di.it = cv;
+		di.index = 0;
+		stack.push_back(di);
+		size = di.it->GetArray().Size();
+	}
+
+	virtual void endArray() override {
+		stack.pop_back();
+	}
+	virtual void propertyName(const char * fieldName) override {
+		propName = fieldName;
+	}
+	virtual void value(Uint32& value) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsUint());
+		value = cv->GetUint();
+	}
+	virtual void value(Sint32& value) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsInt());
+		value = cv->GetInt();
+	}
+	virtual void value(float& value) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsFloat());
+		value = cv->GetFloat();
+	}
+	virtual void value(double& value) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsDouble());
+		value = cv->GetDouble();
+	}
+	virtual void value(bool& value) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsBool());
+		value = cv->GetBool();
+	}
+	virtual void value(std::string& value, Uint32 maxLength) override {
+		auto cv = GetCurrentValue();
+		assert(cv->IsString());
+		assert(maxLength == 0 || cv->GetStringLength() <= maxLength);
+		value = cv->GetString();
+	}
+
+protected:
+
+	rapidjson::Value::ConstValueIterator GetCurrentValue() {
+		if (stack.empty()) {
+			assert(propName == nullptr);
+			return &doc;
+		}
+
+		DocIterator& di = stack.at(0);
+		if (di.it->IsArray()) {
+			assert(di.index >= 0);
+			return &di.it->GetArray()[di.index++];
+		}
+
+		assert(propName != nullptr);
+		rapidjson::Value::ConstValueIterator result = &(*di.it)[propName];
+		propName = nullptr;
+		return result;
+	}
+
+	bool readAllFileData(FILE * fp) {
+		if (fseek(fp, 0, SEEK_END)) {
+			printlog("JsonFileReader: failed to seek end (%d)", errno);
+			return false;
+		}
+
+		long size = ftell(fp);
+		if (fseek(fp, 0, SEEK_SET)) {
+			printlog("JsonFileReader: failed to seek beg (%d)", errno);
+			return false;
+		}
+
+		// reserve an extra byte for the null terminator
+		char * data = (char *)calloc(sizeof(char), size + 1);
+		assert(data);
+
+		size_t bytesRead = fread(data, sizeof(char), size, fp);
+		if (bytesRead != size) {
+			printlog("JsonFileReader: failed to read data (%d)", errno);
+			free(data);
+			return false;
+		}
+
+		// null terminate
+		data[size] = 0;
+
+		rapidjson::ParseResult result = doc.Parse(data);
+
+		free(data);
+
+		if (!result) {
+			printlog("JsonFileReader: parse error: %s (%d)", rapidjson::GetParseError_En(result.Code()), result.Offset());
+			return false;
+		}
+
+		return true;
+	}
+
+	struct DocIterator {
+		rapidjson::Value::ConstValueIterator it;
+		Uint32 index;
+	};
+
+	rapidjson::Document doc;
+	const char * propName = nullptr;
+	std::vector<DocIterator> stack;
+};
+
+class BinaryFileWriter : public FileInterface {
+public:
+
+	BinaryFileWriter(FILE * file)
+	: fp(file)
+	{
+	}
+
+	~BinaryFileWriter() {
+	}
+
+	static bool writeObject(FILE * fp, const FileHelper::SerializationFunc & serialize) {
+		BinaryFileWriter bfw(fp);
+
+		bfw.writeHeader();
+
+		bfw.beginObject();
+		serialize(&bfw);
+		bfw.endObject();
+
+		return true;
+	}
+
+	virtual bool isReading() const override { return false; }
+
+	virtual void beginObject() override {
+	}
+
+	virtual void endObject() override {
+	}
+
+	virtual void beginArray(Uint32 & size) override {
+		fwrite(&size, sizeof(size), 1, fp);
+	}
+
+	virtual void endArray() override {
+	}
+
+	virtual void propertyName(const char * name) override {
+	}
+
+	virtual void value(Uint32& v) override {
+		fwrite(&v, sizeof(v), 1, fp);
+	}
+	virtual void value(Sint32& v) override {
+		fwrite(&v, sizeof(v), 1, fp);
+	}
+	virtual void value(float& v) override {
+		fwrite(&v, sizeof(v), 1, fp);
+	}
+	virtual void value(double& v) override {
+		fwrite(&v, sizeof(v), 1, fp);
+	}
+	virtual void value(bool& v) override {
+		fwrite(&v, sizeof(v), 1, fp);
+	}
+	virtual void value(std::string& v, Uint32 maxLength) override {
+		assert(maxLength == 0 || v.size() <= maxLength);
+		writeStringInternal(v);
+	}
+
+private:
+
+	void writeHeader() {
+		fwrite(&BinaryFormatTag, sizeof(BinaryFormatTag), 1, fp);
+	}
+
+	void writeStringInternal(const std::string& v) {
+		Uint32 len = (Uint32)v.size();
+		fwrite(&len, sizeof(len), 1, fp);
+		if (len) {
+			fwrite(v.c_str(), sizeof(char), len, fp);
+		}
+	}
+
+	FILE* fp = nullptr;
+};
+
+class BinaryFileReader : public FileInterface {
+public:
+
+	BinaryFileReader(FILE * file)
+		: fp(file)
+	{
+	}
+
+	static bool readObject(FILE * fp, const FileHelper::SerializationFunc & serialize) {
+		BinaryFileReader bfr(fp);
+
+		if (!bfr.readHeader()) {
+			return false;
+		}
+
+		bfr.beginObject();
+		serialize(&bfr);
+		bfr.endObject();
+
+		return true;
+	}
+
+	virtual bool isReading() const override { return true; }
+
+	virtual void beginObject() override {
+	}
+
+	virtual void endObject() override {
+	}
+
+	virtual void beginArray(Uint32 & size) override {
+		size_t read = fread(&size, sizeof(size), 1, fp);
+		assert(read == 1);
+	}
+
+	virtual void endArray() override {
+	}
+
+	virtual void propertyName(const char * name) override {
+	}
+
+	virtual void value(Uint32& v) override {
+		size_t read = fread(&v, sizeof(v), 1, fp);
+		assert(read == 1);
+	}
+	virtual void value(Sint32& v) override {
+		size_t read = fread(&v, sizeof(v), 1, fp);
+		assert(read == 1);
+	}
+	virtual void value(float& v) override {
+		size_t read = fread(&v, sizeof(v), 1, fp);
+		assert(read == 1);
+	}
+	virtual void value(double& v) override {
+		size_t read = fread(&v, sizeof(v), 1, fp);
+		assert(read == 1);
+	}
+	virtual void value(bool& v) override {
+		size_t read = fread(&v, sizeof(v), 1, fp);
+		assert(read == 1);
+	}
+	virtual void value(std::string& v, Uint32 maxLength) override {
+		readStringInternal(v);
+		assert(maxLength == 0 || v.size() <= maxLength);
+	}
+
+private:
+
+	bool readHeader() {
+		Uint32 fileFormatTag;
+		size_t read = fread(&fileFormatTag, sizeof(fileFormatTag), 1, fp);
+		if (read != 1) {
+			printlog("BinaryFileReader: failed to read format tag (%d)", errno);
+			return false;
+		}
+
+		if (fileFormatTag != BinaryFormatTag) {
+			printlog("BinaryFileReader: file format tag mismatch (expected %x, got %x)", BinaryFormatTag, fileFormatTag);
+			return false;
+		}
+
+		return true;
+	}
+
+	void readStringInternal(std::string & v) {
+		Uint32 len;
+		size_t read = fread(&len, sizeof(len), 1, fp);
+		assert(read == 1);
+
+		if (len) {
+			v.reserve(len);
+			read = fread(&v[0u], sizeof(char), len, fp);
+			assert(read == len);
+		}
+	}
+
+	FILE* fp;
+};
+
+static EFileFormat GetFileFormat(FILE * file) {
+	Uint32 fileFormatTag = 0;
+	fread(&fileFormatTag, sizeof(fileFormatTag), 1, file);
+	fseek(file, 0, SEEK_SET);
+
+	if (fileFormatTag == BinaryFormatTag) {
+		return EFileFormat::Binary;
+	}
+	else {
+		return EFileFormat::Json;
+	}
+}
+
+bool FileHelper::writeObjectInternal(const char * filename, EFileFormat format, const SerializationFunc& serialize) {
+	FILE * file = fopen(filename, "wb");
+#ifndef NDEBUG
+	printlog("Opening file '%s' for write", filename);
+#endif
+	if (!file) {
+		printlog("Unable to open file '%s' for write (%d)", filename, errno);
+		return false;
+	}
+
+	bool success = false;
+	if (format == EFileFormat::Binary) {
+		success = BinaryFileWriter::writeObject(file, serialize);
+	}
+	else if (format == EFileFormat::Json) {
+		success = JsonFileWriter::writeObject(file, serialize);
+	}
+	else {
+		assert(false);
+	}
+
+	fclose(file);
+
+	return success;
+}
+
+bool FileHelper::readObjectInternal(const char * filename, const SerializationFunc& serialize) {
+	FILE * file = fopen(filename, "rb");
+#ifndef NDEBUG
+	printlog("Opening file '%s' for read", filename);
+#endif
+	if (!file) {
+		printlog("Unable to open file '%s' for read (%d)", filename, errno);
+		return false;
+	}
+
+	EFileFormat format = GetFileFormat(file);
+
+	bool success = false;
+	if (format == EFileFormat::Binary) {
+		success = BinaryFileReader::readObject(file, serialize);
+	}
+	else if(format == EFileFormat::Json) {
+		success = JsonFileReader::readObject(file, serialize);
+	}
+	else {
+		assert(false);
+	}
+
+	fclose(file);
+
+	return success;
+}

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1,0 +1,162 @@
+/**
+	A simple interface for reading and writing objects to files, has support for both json and binary.
+	Basic types, enums and ArrayLists are supported by default, other class and struct types need to
+	implement the "void serialize(FileInterface * file)" function.
+	The interface is symmetric, meaning that there is only a single function for both saving and loading.
+
+	class ExampleClass {
+	private:
+		Uint32 MyNumber;
+		String MyString;
+	public:
+		void serialize(FileInterface * file) {
+			file->property("MyNumber", MyNumber);
+			file->property("MyString", MyString);
+		}
+	};
+*/
+
+#pragma once
+
+#include <functional>
+
+enum class EFileFormat {
+	Json,
+	Binary
+};
+
+class FileInterface {
+public:
+	virtual ~FileInterface() {}
+	
+	// @return true if this interface is reading data from a file, false if it is writing
+	virtual bool isReading() const = 0;
+
+	// Signals the beginning of an object in the file
+	virtual void beginObject() = 0;
+	// Signals the end of an object in the file
+	virtual void endObject() = 0;
+
+	// Signals the beginning of an array in the file
+	// @param size number of items in the array
+	virtual void beginArray(Uint32 & size) = 0;
+	// Signals the end of an array in the file
+	virtual void endArray() = 0;
+
+	// Serializes the name of a property
+	// @param name name of the property 
+	virtual void propertyName(const char * name) = 0;
+
+	// @param v the value to serialize
+	virtual void value(Uint32& v) = 0;
+	// @param v the value to serialize
+	virtual void value(Sint32& v) = 0;
+	// @param v the value to serialize
+	virtual void value(float& v) = 0;
+	// @param v the value to serialize
+	virtual void value(double& v) = 0;
+	// @param v the value to serialize
+	virtual void value(bool& v) = 0;
+	// @param v the value to serialize
+	// @param maxLength maximum length of the string allowed, 0 is no limit
+	virtual void value(std::string& v, Uint32 maxLength = 0) = 0;
+
+	// Serialize an ArrayList with a max length
+	// @param v the value to serialize
+	// @param maxLength maximum number of items, 0 is no limit
+	template<typename T, typename... Args>
+	void value(std::vector<T>& v, Uint32 maxLength = 0, Args ... args) {
+		Uint32 size = (Uint32)v.getSize();
+		beginArray(size);
+		assert(maxLength == 0 || size <= maxLength);
+		v.resize(size);
+		for (Uint32 index = 0; index < size; ++index) {
+			value(v[index], args...);
+		}
+		endArray();
+	}
+
+	// Serialize a pointer by dereferencing it
+	// @param v the pointer to dereference and serialize
+	template<typename T>
+	void value (T*& v) {
+		if (isReading()) {
+			v = new T();
+		}
+		value(*v);
+	}
+
+	// Serializes an enum value as its underlying type to the file
+	// @param t the enum value to serialize
+	template<typename T>
+	typename std::enable_if<std::is_enum<T>::value, void>::type
+	value(T& v) {
+		typename std::underlying_type<T>::type temp = v;
+		value(temp);
+		v = (T)temp;
+	}
+
+	// Serializes a class or struct to the file using it's ::serialize(FileInterface*) function
+	// @param v the object to serialize
+	template<typename T>
+	typename std::enable_if<std::is_class<T>::value, void>::type
+	value(T& v) {
+		beginObject();
+		v.serialize(this);
+		endObject();
+	}
+	
+	// Serializes a fixed-size native array
+	// @param v array to serialize
+	template<typename T, Uint32 Size, typename... Args>
+	void value(T (&v)[Size], Args ... args) {
+		Uint32 size = Size;
+		beginArray(size);
+		assert(size == Size);
+		for (Uint32 index = 0; index < size; ++index) {
+			value(v[index], args...);
+		}
+		endArray();
+	}
+
+	// Helper function to serialize a property name and value at the same time 
+	// @param name name of the property
+	// @param v value to serialize
+	// @param args additional args to pass into the value() function
+	template<typename T, typename... Args>
+	void property(const char * name, T& v, Args ... args) {
+		propertyName(name);
+		value(v, args...);
+	}
+
+};
+
+class FileHelper {
+public:
+	// Write an object's data to a file
+	// @param filename the name of the file to write
+	// @param v the object to write
+	template<typename T>
+	static bool writeObject(const char * filename, EFileFormat format, T & v) {
+		using std::placeholders::_1;
+		SerializationFunc serialize = std::bind(&T::serialize, &v, _1);
+		return writeObjectInternal(filename, format, serialize);
+	}
+
+	// Read an object's data from a file
+	// @param filename the name of the file to read
+	// @param v the object to populate with data
+	template<typename T>
+	static bool readObject(const char * filename, T & v) {
+		using std::placeholders::_1;
+		SerializationFunc serialize = std::bind(&T::serialize, &v, _1);
+		return readObjectInternal(filename, serialize);
+	}
+
+	typedef std::function<void(FileInterface*)> SerializationFunc;
+
+private:
+
+	static bool writeObjectInternal(const char * filename, EFileFormat format, const SerializationFunc& serialize);
+	static bool readObjectInternal(const char * filename, const SerializationFunc& serialize);
+};


### PR DESCRIPTION
Adds files to read/write json to/from classes and structs. Process is pretty simple, there's an example in json.hpp:

```
	class ExampleClass {
	private:
		Uint32 MyNumber;
		String MyString;
	public:
		// defines how to read/write the file to json:
		void serialize(FileInterface * file) {
			file->property("MyNumber", MyNumber);
			file->property("MyString", MyString);
		}
	};
```

Then when you want to read a file into an object:

```
// read an object from a json file:
ExampleClass exampleObject;
FileHelper::readObject("myJsonFile.json", exampleObject);
```

Or write a file from an object:

```
// write an object to a json file:
ExampleClass exampleObject;
FileHelper::writeObject("myJsonFile.json", EFileFormat::Json, exampleObject);
```

The benefits of this are huge. JSON is a standard and widely popular format. You can serialize either text-based JSON or binary json (text-based can be edited with a text editor, binary is significantly faster for serializing). The game will not crash when attempting to read missing properties. Versioning is trivial (simply add a "version" property in the serialize() function, as so):

```
		void serialize(FileInterface * file) {
			int version = 2;
			file->property("version", version);
			if (version < 2) {
				// loading an old version
			} else {
				// loading the latest version
			}
		}
```

This PR adds a new dependency to rapidjson and so modifies the LICENSE.txt to include a blurb about it.

Signed-off-by: SheridanR <sheridan.rathbun@gmail.com>