### PR TITLE
Fix mouse being reset to tab after hitting accept in setting menu.

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -347,7 +347,6 @@ void changeSettingsTab(int option)
 		button->outline = true;
 		int x = button->x + (button->sizex / 2);
 		int y = button->y + (button->sizey / 2);
-		SDL_WarpMouseInWindow(screen, x, y);
 	}
 }
 


### PR DESCRIPTION
- Removed call to SDL_WarpMouseInWindow() which causes the mouse to be set back to the last tab clicked on when hitting the accept button in the options menu.