### PR TITLE
UI elements scaled from virtual screen size to actual screen size

### DIFF
--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -54,10 +54,16 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	if (_size.w <= 0 || _size.h <= 0)
 		return;
 
-	if (pressed) {
-		drawDepressed(_size.x, _size.y, _size.x + _size.w, _size.y + _size.h);
-	} else {
-		drawWindow(_size.x, _size.y, _size.x + _size.w, _size.y + _size.h);
+	{
+		int x = (_size.x) * (float)xres / (float)Frame::virtualScreenX;
+		int y = (_size.x) * (float)yres / (float)Frame::virtualScreenY;
+		int w = (_size.x + _size.w) * (float)xres / (float)Frame::virtualScreenX;
+		int h = (_size.x + _size.h) * (float)yres / (float)Frame::virtualScreenY;
+		if (pressed) {
+			drawDepressed(x, y, w, h);
+		} else {
+			drawWindow(x, y, w, h);
+		}
 	}
 
 	if (!text.empty() && style != STYLE_CHECKBOX) {
@@ -73,7 +79,13 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			if (pos.w <= 0 || pos.h <= 0) {
 				return;
 			}
-			_text->drawColor(SDL_Rect(), pos, textColor);
+
+			SDL_Rect scaledPos;
+			scaledPos.x = pos.x * (float)xres / (float)Frame::virtualScreenX;
+			scaledPos.y = pos.y * (float)yres / (float)Frame::virtualScreenY;
+			scaledPos.w = pos.w * (float)xres / (float)Frame::virtualScreenX;
+			scaledPos.h = pos.h * (float)yres / (float)Frame::virtualScreenY;
+			_text->drawColor(SDL_Rect(), scaledPos, textColor);
 		}
 	} else if (icon.c_str()) {
 		// we check a second time, just incase the cache was dumped and the original pointer invalidated.
@@ -96,7 +108,12 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 				section.w = ((float)pos.w / (size.w - border * 2)) * w;
 				section.h = ((float)pos.h / (size.h - border * 2)) * h;
 
-				iconImg->draw(&section, pos);
+				SDL_Rect scaledPos;
+				scaledPos.x = pos.x * (float)xres / (float)Frame::virtualScreenX;
+				scaledPos.y = pos.y * (float)yres / (float)Frame::virtualScreenY;
+				scaledPos.w = pos.w * (float)xres / (float)Frame::virtualScreenX;
+				scaledPos.h = pos.h * (float)yres / (float)Frame::virtualScreenY;
+				iconImg->draw(&section, scaledPos);
 			}
 		}
 	}
@@ -122,7 +139,12 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			section.w = ((float)pos.w / (size.h - border * 2)) * w;
 			section.h = ((float)pos.h / (size.h - border * 2)) * h;
 
-			iconImg->draw(&section, pos);
+			SDL_Rect scaledPos;
+			scaledPos.x = pos.x * (float)xres / (float)Frame::virtualScreenX;
+			scaledPos.y = pos.y * (float)yres / (float)Frame::virtualScreenY;
+			scaledPos.w = pos.w * (float)xres / (float)Frame::virtualScreenX;
+			scaledPos.h = pos.h * (float)yres / (float)Frame::virtualScreenY;
+			iconImg->draw(&section, scaledPos);
 		}
 	}
 }

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -56,9 +56,9 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 	{
 		int x = (_size.x) * (float)xres / (float)Frame::virtualScreenX;
-		int y = (_size.x) * (float)yres / (float)Frame::virtualScreenY;
+		int y = (_size.y) * (float)yres / (float)Frame::virtualScreenY;
 		int w = (_size.x + _size.w) * (float)xres / (float)Frame::virtualScreenX;
-		int h = (_size.x + _size.h) * (float)yres / (float)Frame::virtualScreenY;
+		int h = (_size.y + _size.h) * (float)yres / (float)Frame::virtualScreenY;
 		if (pressed) {
 			drawDepressed(x, y, w, h);
 		} else {

--- a/src/ui/Field.cpp
+++ b/src/ui/Field.cpp
@@ -70,8 +70,14 @@ void Field::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	if (rect.w <= 0 || rect.h <= 0)
 		return;
 
+	SDL_Rect scaledRect;
+	scaledRect.x = rect.x * (float)xres / (float)Frame::virtualScreenX;
+	scaledRect.y = rect.y * (float)yres / (float)Frame::virtualScreenY;
+	scaledRect.w = rect.w * (float)xres / (float)Frame::virtualScreenX;
+	scaledRect.h = rect.h * (float)yres / (float)Frame::virtualScreenY;
+
 	if (selected) {
-		drawRect(&rect, SDL_MapRGB(mainsurface->format, 0, 0, 127), 255);
+		drawRect(&scaledRect, SDL_MapRGB(mainsurface->format, 0, 0, 127), 255);
 	}
 
 	bool showCursor = (ticks - cursorflash) % TICKS_PER_SECOND < TICKS_PER_SECOND / 2;
@@ -161,10 +167,15 @@ void Field::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		return;
 
 	if (selectAll && selected) {
-		drawRect(&rect, SDL_MapRGB(mainsurface->format, 127, 127, 0), 255);
+		drawRect(&scaledRect, SDL_MapRGB(mainsurface->format, 127, 127, 0), 255);
 	}
 
-	text->drawColor(src, dest, color);
+	SDL_Rect scaledDest;
+	scaledDest.x = dest.x * (float)xres / (float)Frame::virtualScreenX;
+	scaledDest.y = dest.y * (float)yres / (float)Frame::virtualScreenY;
+	scaledDest.w = dest.w * (float)xres / (float)Frame::virtualScreenX;
+	scaledDest.h = dest.h * (float)yres / (float)Frame::virtualScreenY;
+	text->drawColor(src, scaledDest, color);
 }
 
 Field::result_t Field::process(SDL_Rect _size, SDL_Rect _actualSize, const bool usable) {

--- a/src/ui/Frame.cpp
+++ b/src/ui/Frame.cpp
@@ -123,7 +123,12 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 	// draw frame background
 	if (!hollow) {
-		drawRect(&_size, color, (Uint8)(color>>mainsurface->format->Ashift));
+		SDL_Rect scaledSize;
+		scaledSize.x = _size.x * (float)xres / (float)Frame::virtualScreenX;
+		scaledSize.y = _size.y * (float)yres / (float)Frame::virtualScreenY;
+		scaledSize.w = _size.w * (float)xres / (float)Frame::virtualScreenX;
+		scaledSize.h = _size.h * (float)yres / (float)Frame::virtualScreenY;
+		drawRect(&scaledSize, color, (Uint8)(color>>mainsurface->format->Ashift));
 	}
 
 	Sint32 mousex = (mousex / (float)xres) * (float)Frame::virtualScreenX;
@@ -136,10 +141,10 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 		// slider rail
 		SDL_Rect barRect;
-		barRect.x = _size.x;
-		barRect.y = _size.y + _size.h;
-		barRect.w = _size.w;
-		barRect.h = sliderSize;
+		barRect.x = (_size.x) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.y = (_size.y + _size.h) * (float)yres / (float)Frame::virtualScreenY;
+		barRect.w = (_size.w) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.h = (sliderSize) * (float)yres / (float)Frame::virtualScreenY;
 		drawDepressed(barRect.x, barRect.y, barRect.x + barRect.w, barRect.y + barRect.h);
 
 		// handle
@@ -152,21 +157,26 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		handleRect.y = _size.y + _size.h;
 		handleRect.w = handleSize;
 		handleRect.h = sliderSize;
+
+		int x = (handleRect.x) * (float)xres / (float)Frame::virtualScreenX;
+		int y = (handleRect.x) * (float)yres / (float)Frame::virtualScreenY;
+		int w = (handleRect.x + handleRect.w) * (float)xres / (float)Frame::virtualScreenX;
+		int h = (handleRect.x + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
 		if (rectContainsPoint(barRect, omousex, omousey)) {
 			// TODO highlight
-			drawWindow(handleRect.x, handleRect.y, handleRect.x + handleRect.w, handleRect.y + handleRect.h);
+			drawWindow(x, y, w, h);
 		} else {
-			drawWindow(handleRect.x, handleRect.y, handleRect.x + handleRect.w, handleRect.y + handleRect.h);
+			drawWindow(x, y, w, h);
 		}
 	}
 
 	// vertical slider
 	if (actualSize.h > size.h && _size.y) {
 		SDL_Rect barRect;
-		barRect.x = _size.x + _size.w;
-		barRect.y = _size.y;
-		barRect.w = sliderSize;
-		barRect.h = _size.h;
+		barRect.x = (_size.x + _size.w) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.y = (_size.y) * (float)yres / (float)Frame::virtualScreenY;
+		barRect.w = (sliderSize) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.h = (_size.h) * (float)yres / (float)Frame::virtualScreenY;
 		drawRect(&barRect, color, (Uint8)(color>>mainsurface->format->Ashift));
 
 		// handle
@@ -179,20 +189,26 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		handleRect.y = _size.y + sliderPos;
 		handleRect.w = sliderSize;
 		handleRect.h = handleSize;
+
+		int x = (handleRect.x) * (float)xres / (float)Frame::virtualScreenX;
+		int y = (handleRect.x) * (float)yres / (float)Frame::virtualScreenY;
+		int w = (handleRect.x + handleRect.w) * (float)xres / (float)Frame::virtualScreenX;
+		int h = (handleRect.x + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
 		if (rectContainsPoint(barRect, omousex, omousey)) {
-			drawWindow(handleRect.x, handleRect.y, handleRect.x + handleRect.w, handleRect.y + handleRect.h);
+			// TODO highlight
+			drawWindow(x, y, w, h);
 		} else {
-			drawWindow(handleRect.x, handleRect.y, handleRect.x + handleRect.w, handleRect.y + handleRect.h);
+			drawWindow(x, y, w, h);
 		}
 	}
 
 	// slider filler (at the corner between sliders)
 	if (actualSize.w > size.w && actualSize.h > size.h) {
 		SDL_Rect barRect;
-		barRect.x = _size.x + _size.w;
-		barRect.y = _size.y + _size.h;
-		barRect.w = sliderSize;
-		barRect.h = sliderSize;
+		barRect.x = (_size.x + _size.w) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.y = (_size.y + _size.h) * (float)yres / (float)Frame::virtualScreenY;
+		barRect.w = (sliderSize) * (float)xres / (float)Frame::virtualScreenX;
+		barRect.h = (sliderSize) * (float)yres / (float)Frame::virtualScreenY;
 		// TODO different border styles
 		if (border > 0) {
 			switch (borderStyle) {
@@ -234,6 +250,11 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			dest.y = std::max(_size.y, pos.y);
 			dest.w = pos.w - (dest.x - pos.x) - std::max(0, (pos.x + pos.w) - (_size.x + _size.w));
 			dest.h = pos.h - (dest.y - pos.y) - std::max(0, (pos.y + pos.h) - (_size.y + _size.h));
+			SDL_Rect scaledDest;
+			scaledDest.x = dest.x * (float)xres / (float)Frame::virtualScreenX;
+			scaledDest.y = dest.y * (float)yres / (float)Frame::virtualScreenY;
+			scaledDest.w = dest.w * (float)xres / (float)Frame::virtualScreenX;
+			scaledDest.h = dest.h * (float)yres / (float)Frame::virtualScreenY;
 
 			SDL_Rect src;
 			src.x = std::max(0, _size.x - pos.x);
@@ -241,7 +262,7 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			src.w = pos.w - (dest.x - pos.x) - std::max(0, (pos.x + pos.w) - (_size.x + _size.w));
 			src.h = pos.h - (dest.y - pos.y) - std::max(0, (pos.y + pos.h) - (_size.y + _size.h));
 
-			actualImage->drawColor(&src, dest, image->color);
+			actualImage->drawColor(&src, scaledDest, image->color);
 		}
 	}
 
@@ -288,6 +309,11 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		// TODO entry highlighting
 		SDL_Rect entryback = dest;
 		entryback.w = _size.w - border * 2;
+		
+		entryback.x = entryback.x * (float)xres / (float)Frame::virtualScreenX;
+		entryback.y = entryback.y * (float)yres / (float)Frame::virtualScreenY;
+		entryback.w = entryback.w * (float)xres / (float)Frame::virtualScreenX;
+		entryback.h = entryback.h * (float)yres / (float)Frame::virtualScreenY;
 		if (entry.pressed) {
 			drawRect(&entryback, color, (Uint8)(color>>mainsurface->format->Ashift));
 		} else if (entry.highlighted) {
@@ -296,7 +322,12 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			drawRect(&entryback, color, (Uint8)(color>>mainsurface->format->Ashift));
 		}
 
-		text->drawColor(src, dest, entry.color);
+		SDL_Rect scaledDest;
+		scaledDest.x = dest.x * (float)xres / (float)Frame::virtualScreenX;
+		scaledDest.y = dest.y * (float)yres / (float)Frame::virtualScreenY;
+		scaledDest.w = dest.w * (float)xres / (float)Frame::virtualScreenX;
+		scaledDest.h = dest.h * (float)yres / (float)Frame::virtualScreenY;
+		text->drawColor(src, scaledDest, entry.color);
 	}
 
 	// render fields
@@ -333,9 +364,17 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 				int border = tooltip_border_width;
 
+				src.x = src.x * (float)xres / (float)Frame::virtualScreenX;
+				src.y = src.y * (float)yres / (float)Frame::virtualScreenY;
+				src.w = src.w * (float)xres / (float)Frame::virtualScreenX;
+				src.h = src.h * (float)yres / (float)Frame::virtualScreenY;
 				drawRect(&src, tooltip_border_color, (Uint8)(tooltip_border_color>>mainsurface->format->Ashift));
 
 				SDL_Rect src2{src.x + border, src.y + border, src.w - border * 2, src.h - border * 2};
+				src2.x = src2.x * (float)xres / (float)Frame::virtualScreenX;
+				src2.y = src2.y * (float)yres / (float)Frame::virtualScreenY;
+				src2.w = src2.w * (float)xres / (float)Frame::virtualScreenX;
+				src2.h = src2.h * (float)yres / (float)Frame::virtualScreenY;
 				drawRect(&src2, tooltip_background, (Uint8)(tooltip_background>>mainsurface->format->Ashift));
 
 				text->drawColor(SDL_Rect{0,0,0,0}, SDL_Rect{src.x + 1, src.y + 1, 0, 0}, tooltip_text_color);

--- a/src/ui/Frame.cpp
+++ b/src/ui/Frame.cpp
@@ -159,9 +159,9 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		handleRect.h = sliderSize;
 
 		int x = (handleRect.x) * (float)xres / (float)Frame::virtualScreenX;
-		int y = (handleRect.x) * (float)yres / (float)Frame::virtualScreenY;
+		int y = (handleRect.y) * (float)yres / (float)Frame::virtualScreenY;
 		int w = (handleRect.x + handleRect.w) * (float)xres / (float)Frame::virtualScreenX;
-		int h = (handleRect.x + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
+		int h = (handleRect.y + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
 		if (rectContainsPoint(barRect, omousex, omousey)) {
 			// TODO highlight
 			drawWindow(x, y, w, h);
@@ -191,9 +191,9 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		handleRect.h = handleSize;
 
 		int x = (handleRect.x) * (float)xres / (float)Frame::virtualScreenX;
-		int y = (handleRect.x) * (float)yres / (float)Frame::virtualScreenY;
+		int y = (handleRect.y) * (float)yres / (float)Frame::virtualScreenY;
 		int w = (handleRect.x + handleRect.w) * (float)xres / (float)Frame::virtualScreenX;
-		int h = (handleRect.x + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
+		int h = (handleRect.y + handleRect.h) * (float)yres / (float)Frame::virtualScreenY;
 		if (rectContainsPoint(barRect, omousex, omousey)) {
 			// TODO highlight
 			drawWindow(x, y, w, h);

--- a/src/ui/Slider.cpp
+++ b/src/ui/Slider.cpp
@@ -24,9 +24,9 @@ void Slider::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	_railSize.h = std::min(railSize.h, _size.h - railSize.y + _actualSize.y) + std::min(0, railSize.y - _actualSize.y);
 	if (_railSize.w > 0 && _railSize.h > 0) {
 		int x = (_railSize.x) * (float)xres / (float)Frame::virtualScreenX;
-		int y = (_railSize.x) * (float)yres / (float)Frame::virtualScreenY;
+		int y = (_railSize.y) * (float)yres / (float)Frame::virtualScreenY;
 		int w = (_railSize.x + _railSize.w) * (float)xres / (float)Frame::virtualScreenX;
-		int h = (_railSize.x + _railSize.h) * (float)yres / (float)Frame::virtualScreenY;
+		int h = (_railSize.y + _railSize.h) * (float)yres / (float)Frame::virtualScreenY;
 		drawDepressed(x, y, w, h);
 	}
 	
@@ -36,11 +36,10 @@ void Slider::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	_handleSize.w = std::min(handleSize.w, _size.w - handleSize.x + _actualSize.x) + std::min(0, handleSize.x - _actualSize.x);
 	_handleSize.h = std::min(handleSize.h, _size.h - handleSize.y + _actualSize.y) + std::min(0, handleSize.y - _actualSize.y);
 	if (_handleSize.w > 0 && _handleSize.h > 0) {
-		bool h = highlighted | selected;
 		int x = (_handleSize.x) * (float)xres / (float)Frame::virtualScreenX;
-		int y = (_handleSize.x) * (float)yres / (float)Frame::virtualScreenY;
+		int y = (_handleSize.y) * (float)yres / (float)Frame::virtualScreenY;
 		int w = (_handleSize.x + _handleSize.w) * (float)xres / (float)Frame::virtualScreenX;
-		int h = (_handleSize.x + _handleSize.h) * (float)yres / (float)Frame::virtualScreenY;
+		int h = (_handleSize.y + _handleSize.h) * (float)yres / (float)Frame::virtualScreenY;
 		drawWindow(x, y, w, h);
 	}
 }

--- a/src/ui/Slider.cpp
+++ b/src/ui/Slider.cpp
@@ -23,7 +23,11 @@ void Slider::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	_railSize.w = std::min(railSize.w, _size.w - railSize.x + _actualSize.x) + std::min(0, railSize.x - _actualSize.x);
 	_railSize.h = std::min(railSize.h, _size.h - railSize.y + _actualSize.y) + std::min(0, railSize.y - _actualSize.y);
 	if (_railSize.w > 0 && _railSize.h > 0) {
-		drawDepressed(_railSize.x, _railSize.y, _railSize.x + _railSize.w, _railSize.y + _railSize.h);
+		int x = (_railSize.x) * (float)xres / (float)Frame::virtualScreenX;
+		int y = (_railSize.x) * (float)yres / (float)Frame::virtualScreenY;
+		int w = (_railSize.x + _railSize.w) * (float)xres / (float)Frame::virtualScreenX;
+		int h = (_railSize.x + _railSize.h) * (float)yres / (float)Frame::virtualScreenY;
+		drawDepressed(x, y, w, h);
 	}
 	
 	// draw handle
@@ -33,7 +37,11 @@ void Slider::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	_handleSize.h = std::min(handleSize.h, _size.h - handleSize.y + _actualSize.y) + std::min(0, handleSize.y - _actualSize.y);
 	if (_handleSize.w > 0 && _handleSize.h > 0) {
 		bool h = highlighted | selected;
-		drawWindow(_handleSize.x, _handleSize.y, _handleSize.x + _handleSize.w, _handleSize.y + _handleSize.h);
+		int x = (_handleSize.x) * (float)xres / (float)Frame::virtualScreenX;
+		int y = (_handleSize.x) * (float)yres / (float)Frame::virtualScreenY;
+		int w = (_handleSize.x + _handleSize.w) * (float)xres / (float)Frame::virtualScreenX;
+		int h = (_handleSize.x + _handleSize.h) * (float)yres / (float)Frame::virtualScreenY;
+		drawWindow(x, y, w, h);
 	}
 }
 


### PR DESCRIPTION
Really simple PR that scales UI elements graphically from the virtual screen dimensions (1080p) to the real screen dimensions.

Check that I didn't mix any usage of xres/yres up! Some x + width / y + height properties are combined inline during scaling.

Signed-off-by: SheridanR <sheridan.rathbun@gmail.com>