### PR TITLE
Fix OpenAL segfault in hamlet

### DIFF
--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -142,9 +142,9 @@ struct FMOD_VECTOR {
 extern OPENAL_BUFFER** sounds;
 extern Uint32 numsounds;
 extern OPENAL_BUFFER** minesmusic;
-#define NUMMINESMUSIC 4
+#define NUMMINESMUSIC 5
 extern OPENAL_BUFFER** swampmusic;
-#define NUMSWAMPMUSIC 3
+#define NUMSWAMPMUSIC 4
 extern OPENAL_BUFFER** labyrinthmusic;
 #define NUMLABYRINTHMUSIC 3
 extern OPENAL_BUFFER** ruinsmusic;


### PR DESCRIPTION
This fixes a crash in hamlet when using a binary compiled for OpenAL that is caused by the `NUMMINESMUSIC` being different in OpenAL to FMOD ([the fmod constant is here](https://github.com/TurningWheel/Barony/blob/master/src/sound.hpp#L55)).

I also checked the other constants, and `NUMSWAMPMUSIC` is also wrong, but this doesn't lead to a segfault as the track just winds up unused instead. I've fixed this one as well so that the track can play when randomly chosen.