### PR TITLE
Add GLVND OpenGL detection as a GLX(X11) alternative and remove the glut header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,17 @@ IF (APPLE)
   find_package(SDL2_ttf REQUIRED)
   find_package(IOKit REQUIRED)
 ELSE (APPLE)
-	find_package(OpenGL REQUIRED)
+
+        find_package(OpenGL QUIET)
+	IF(OpenGL_FOUND)
+		message(STATUS "Using OpenGL GLX for OpenGL")
+	ELSE(OpenGL_FOUND)
+		# If we couldn't find old GLX package, try to use modern libglvnd libOpenGL.so instead.
+		message(STATUS "Using GLVND for OpenGL")
+		FIND_LIBRARY(OpenGL_LIBRARY OpenGL)
+		SET(EXTRA_LIBS ${OpenGL_LIBRARY})
+        ENDIF(OpenGL_FOUND)
+
 	IF(NOT WIN32)
 		INCLUDE(FindPkgConfig)
 		PKG_SEARCH_MODULE(SDL2 REQUIRED sdl2)

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -116,7 +116,6 @@ extern bool autoLimbReload;
  #ifndef NINTENDO
   #define GL_GLEXT_PROTOTYPES
   #include <GL/gl.h>
-  #include <GL/glu.h>
  #endif
  #include <GL/glext.h>
  #include "SDL_opengl.h"


### PR DESCRIPTION
Hi there @TurningWheel 

I wanted Barony running on X11-less systems, which offer the lowest possible latency.
Since Barony runs on OpenGL (not GLES, to my knowledge) and accesses the GL functions directly, the only way is to add suport for the modern and vendor-neutral GLVND GL, which is provided by MESA when built with GLVND support on: this way, we don't depend on any X11-related library, yet we can have full OpenGL without X11.   

I have also removed the line trying to use `glu.h` in src/main.hpp, since GLUT is not used anymore (Good! Old GLUT stuff is not needed anymore) and trying to use `glu.h` causes building to fail on X11-less systems which of course don't have GLUT either.

So: This allows the Barony engine to be built on modern GNU/Linux systems without depending on X11.
For example, I have just built it on my Raspberry Pi4 running aacrh64 GNU/Linux with latest stable MESA (21.0.1 as of today) with no X11.
(Just remember that MESA with GLVND support is needed for building against GLVND OpenGL! Most modern common desktop distros support it anyway.) 