### PR TITLE
 Second possible implementation for how we could do font stuff...

### DIFF
--- a/src/cppfuncs.hpp
+++ b/src/cppfuncs.hpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <sstream>
 #include "prng.hpp"
 
 template<typename T>
@@ -33,4 +34,23 @@ T randomEntryFromVector(std::vector<T> vector)
 #endif
 
 	return vector[rand() % vector.size()];
+}
+
+inline std::vector<std::string> splitStringByDelimeter(std::string str, char delimeter)
+{
+	std::vector<std::string> lines;
+
+	std::string line;
+	std::stringstream ss(str);
+	while(std::getline(ss, line, delimeter))
+	{
+		lines.push_back(line);
+	}
+	if (str[str.length() - 1] == '\n')
+	{
+		//Don't drop the last element of the vector if the last character is a newline...
+		lines.push_back(string());
+	}
+
+	return lines;
 }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -26,6 +26,7 @@
 #include "steam.hpp"
 #endif // STEAMWORKS
 
+float UI_SCALE_EXPERIMENT = 1.0f;
 
 //#include "player.hpp"
 

--- a/src/external/fontstash/fontstash.h
+++ b/src/external/fontstash/fontstash.h
@@ -26,6 +26,9 @@
 #ifdef WINDOWS
  #include <windows.h>
 #endif
+#ifdef NINTENDO
+ #include <stdlib.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -816,3 +816,5 @@ extern SteamStat_t g_SteamGlobalStats[NUM_GLOBAL_STEAM_STATISTICS];
  #define getSizeOfText(A, B, C, D) TTF_SizeUTF8(A, B, C, D)
  #define getHeightOfFont(A) TTF_FontHeight(A)
 #endif // NINTENDO
+
+extern float UI_SCALE_EXPERIMENT;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1639,6 +1639,9 @@ void handleMainMenu(bool mode)
 		font->drawTextColor("run the gauntlet f00lz!!1!", 100, text_y, 0xFFEF23FF, 22.39f);
 
 		font->drawTextColor("Pootis pootis blarg blarg!", 0, 0, 0xFFFFFFFF);
+		UI_SCALE_EXPERIMENT = 2.0f;
+		font->drawTextColor("Pootis pootis blarg blarg!", 0, 0, 0xFFFFFFFF);
+		UI_SCALE_EXPERIMENT = 1.0f;
 
 		if ( mode && subtitleVisible )
 		{

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1617,9 +1617,15 @@ void handleMainMenu(bool mode)
 			drawImageScaled(title_bmp, nullptr, &src);
 		}
 
-		Font* font = Font::get("lang/en.ttf");
-		//Font* font = Font::get("fonts/pixel_maz.ttf");
+#ifdef NINTENDO
+		//Font* font = Font::get("rom://lang/en.ttf");
+		Font* font = Font::get("rom://fonts/pixel_maz.ttf");
+		//Font* font = Font::get("rom://fonts/pixelmix.ttf");
+#else
+		//Font* font = Font::get("lang/en.ttf");
+		Font* font = Font::get("fonts/pixel_maz.ttf");
 		//Font* font = Font::get("fonts/pixelmix.ttf");
+#endif
 		if (!font) {
 			return;
 		}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1617,48 +1617,28 @@ void handleMainMenu(bool mode)
 			drawImageScaled(title_bmp, nullptr, &src);
 		}
 
-		Text* text = Text::get("This. Is. For. BARONY!!", Font::defaultFont);
-		if (!text) {
+		Font* font = Font::get(Font::defaultFont);
+		if (!font) {
 			return;
 		}
-		SDL_Rect dest;
-		dest.x = 100;
-		dest.y = yres - 100;
-		dest.w = 0;
-		dest.h = 0;
-		SDL_Rect src_text_rect;
-		src_text_rect.w = 0;
-		src_text_rect.h = 0;
-		text->drawColor(src_text_rect, dest, 0xFF00FFFF);
+		font->drawTextColor("This. Is. For. BARONY!!", 100, yres - 100, 0xFF00FFFF);
 
-		text = Text::get("What does the BARON say??", Font::defaultFont);
-		if (!text) {
-			std::cerr << "Failed to get text 2!\n";
-			return;
-		}
-		text->drawColor(300, 32, 0xFFFF00FF, 32.0f);
+		font->drawTextColor("What does the BARON say??", 300, 32, 0xFFFF00FF, 32.0f);
 
 		int text_y = 300;
-		text = Text::get("STB TTF SPONSORED BY", Font::defaultFont);
-		if (!text) {
-			std::cerr << "Failed to get text 3!\n";
-			return;
-		}
-		text->drawColor(32, text_y, 0xFFFF00FF, 92.0f);
-		text_y += text->getHeight() + 4;
-		text = Text::get("POTATO KING", Font::defaultFont);
-		if (!text) {
-			std::cerr << "Failed to get text 4!\n";
-			return;
-		}
-		text->drawColor(32, text_y, 0xFFEF23FF, 92.0f);
-		text_y += text->getHeight();
-		text = Text::get("run the gauntlet f00lz!!1!", Font::defaultFont);
-		if (!text) {
-			std::cerr << "Failed to get text 5!\n";
-			return;
-		}
-		text->drawColor(100, text_y, 0xFFEF23FF, 22.39f);
+		font->drawTextColor("STB TTF SPONSORED BY", 32, text_y, 0xFFFF00FF, 92.0f);
+		text_y += font->height(92.0f);
+		// font->drawTextColor("      POTATO KING", 32, text_y, 0xFFEF23F3, 92.0f);
+		font->drawTextColor("      POTATO KING", 32, text_y, 0xFF012345, 92.0f);
+		int text_x;
+		int test_height;
+		font->sizeText("      POTATO KING", &text_x, &test_height, 92.0f);
+		font->drawTextColor("πατάτα", 32 + text_x + 8, text_y, 0xFF54FF45, 32.99f);
+		//text_y += font->height(92.0f) + 4;
+		text_y += test_height;
+		font->drawTextColor("run the gauntlet f00lz!!1!", 100, text_y, 0xFFEF23FF, 22.39f);
+
+		font->drawTextColor("Pootis pootis blarg blarg!", 0, 0, 0xFFFFFFFF);
 
 		if ( mode && subtitleVisible )
 		{

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1617,7 +1617,9 @@ void handleMainMenu(bool mode)
 			drawImageScaled(title_bmp, nullptr, &src);
 		}
 
-		Font* font = Font::get(Font::defaultFont);
+		Font* font = Font::get("lang/en.ttf");
+		//Font* font = Font::get("fonts/pixel_maz.ttf");
+		//Font* font = Font::get("fonts/pixelmix.ttf");
 		if (!font) {
 			return;
 		}
@@ -1642,6 +1644,20 @@ void handleMainMenu(bool mode)
 		UI_SCALE_EXPERIMENT = 2.0f;
 		font->drawTextColor("Pootis pootis blarg blarg!", 0, 0, 0xFFFFFFFF);
 		UI_SCALE_EXPERIMENT = 1.0f;
+
+
+		//OK! Now, test the newline and tab stuff code!
+		text_x = 700;
+		text_y = 400;
+		font->drawTextColor("For all decent\n\npuppies\neat\npotato!", text_x, text_y, 0xFF10FFFF, 34.0f);
+		text_x += font->textWidth("For all decent\n\npuppies\neat\npotato!", 34.0f);
+		font->drawTextColor("||except for Buddy,\tof course!", text_x, text_y, 0xFF10FFFF, 34.0f);
+		
+		text_x = 500;
+		text_y = 600;
+		font->drawTextColor("a horse is a horse,\t", text_x, text_y, 0xFF10FFFF, 54.0f);
+		text_x += font->textWidth("a horse is a horse,\t", 54.0f);
+		font->drawTextColor("of course!", text_x, text_y, 0xFF10FFFF, 54.0f);
 
 		if ( mode && subtitleVisible )
 		{

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -88,7 +88,7 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			Font* _font = Font::get(font.c_str());
 			if (_font) {
 				int w, h;
-				_font->sizeText(text.c_str(), &w, &h);
+				_font->sizeText(text, &w, &h);
 				int x = (style != STYLE_DROPDOWN) ?
 					(size.w - w) / 2 :
 					5 + border;
@@ -117,6 +117,7 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 				scaledPos.y = pos.y * (float)yres / (float)Frame::virtualScreenY;
 				scaledPos.w = pos.w * (float)xres / (float)Frame::virtualScreenX;
 				scaledPos.h = pos.h * (float)yres / (float)Frame::virtualScreenY;
+				//TODO: If we want to go with this method, we have to recalculate the point size here...
 				_font->drawTextColor(text, scaledPos.x, scaledPos.y, textColor);
 			}
 		} else if (icon.c_str()) {

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -85,10 +85,10 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 	if (style != STYLE_CHECKBOX || pressed) {
 		if (!text.empty()) {
-			Text* _text = Text::get(text.c_str(), font.c_str());
-			if (_text) {
-				int w = _text->getWidth(); //TODO: This won't work because text hasn't been drawn yet, so this value hasn't been cached yet...
-				int h = _text->getHeight();
+			Font* _font = Font::get(font.c_str());
+			if (_font) {
+				int w, h;
+				_font->sizeText(text.c_str(), &w, &h);
 				int x = (style != STYLE_DROPDOWN) ?
 					(size.w - w) / 2 :
 					5 + border;
@@ -117,7 +117,7 @@ void Button::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 				scaledPos.y = pos.y * (float)yres / (float)Frame::virtualScreenY;
 				scaledPos.w = pos.w * (float)xres / (float)Frame::virtualScreenX;
 				scaledPos.h = pos.h * (float)yres / (float)Frame::virtualScreenY;
-				_text->drawColor(section, scaledPos, textColor);
+				_font->drawTextColor(text, scaledPos.x, scaledPos.y, textColor);
 			}
 		} else if (icon.c_str()) {
 			Image* iconImg = Image::get(icon.c_str());

--- a/src/ui/Field.cpp
+++ b/src/ui/Field.cpp
@@ -106,7 +106,7 @@ void Field::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 
 	// get the size of the rendered text
 	int textSizeW, textSizeH;
-	actualFont->sizeText(str.c_str(), &textSizeW, &textSizeH);
+	actualFont->sizeText(str, &textSizeW, &textSizeH);
 
 	if (selected) {
 		textSizeH += 2;

--- a/src/ui/Field.cpp
+++ b/src/ui/Field.cpp
@@ -99,23 +99,14 @@ void Field::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 		str.assign(text);
 	}
 
-	Text* text = nullptr;
-	if (!str.empty()) {
-		text = Text::get(str.c_str(), font.c_str());
-		if (!text) {
-			return;
-		}
-	} else {
-		return;
-	}
 	Font* actualFont = Font::get(font.c_str());
 	if (!actualFont) {
 		return;
 	}
 
 	// get the size of the rendered text
-	int textSizeW = text->getWidth();
-	int textSizeH = text->getHeight();
+	int textSizeW, textSizeH;
+	actualFont->sizeText(str.c_str(), &textSizeW, &textSizeH);
 
 	if (selected) {
 		textSizeH += 2;
@@ -179,7 +170,7 @@ void Field::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 	scaledDest.y = dest.y * (float)yres / (float)Frame::virtualScreenY;
 	scaledDest.w = dest.w * (float)xres / (float)Frame::virtualScreenX;
 	scaledDest.h = dest.h * (float)yres / (float)Frame::virtualScreenY;
-	text->drawColor(src, scaledDest, color);
+	actualFont->drawTextColor(str, scaledDest.x, scaledDest.y, color);
 }
 
 Field::result_t Field::process(SDL_Rect _size, SDL_Rect _actualSize, const bool usable) {

--- a/src/ui/Font.cpp
+++ b/src/ui/Font.cpp
@@ -123,7 +123,7 @@ void Font::drawTextColor(std::string str, int x, int y, const Uint32& color, int
 	glViewport(0, 0, xres, yres);
 	glLoadIdentity();
 	//glOrtho(0, xres, 0, yres, -1, 1);
-	glOrtho(0, xres, yres, 0, -1, 1);
+	glOrtho(0, xres / UI_SCALE_EXPERIMENT, yres / UI_SCALE_EXPERIMENT, 0, -1, 1);
 	glMatrixMode(GL_MODELVIEW);
 
 	fonsDrawText(fontstash, x, y, str.c_str(), nullptr);

--- a/src/ui/Font.hpp
+++ b/src/ui/Font.hpp
@@ -31,11 +31,11 @@ public:
 	//! @param out_w the integer to hold the width
 	//! @param out_h the integer to hold the height
 	//! @return 0 on success, non-zero on error
-	int sizeText(const char* str, int* out_w, int* out_h) const;
+	int sizeText(const char* str, int* out_w, int* out_h, int override_pointsize = 0) const;
 
 	//! get the height of the font
 	//! @return the font height in pixels
-	int height() const;
+	int height(int override_pointsize = 0) const;
 
 	//! get a Font object from the engine
 	//! @param name The Font name
@@ -44,6 +44,13 @@ public:
 
 	//! dump engine's font cache
 	static void dumpCache();
+
+	//! draws the text
+	void drawText(std::string str, int x, int y, int override_pointsize = 0);
+
+	//! draws the text with the given color
+	//TODO: Maybe we can hack Fontstash to support scaling, if we need it?
+	void drawTextColor(std::string str, int x, int y, const Uint32& color, int override_pointsize = 0); //TODO.
 
 private:
 	std::string name;

--- a/src/ui/Font.hpp
+++ b/src/ui/Font.hpp
@@ -16,9 +16,20 @@ private:
 	Font& operator=(const Font&) = delete;
 	Font& operator=(Font&&) = delete;
 
+	//! helper function for sizeText(), except operates on just one line.
+	int sizeLine(std::string str, int* out_w, int* out_h, int override_pointsize = 0) const;
+
+	//! helper function for drawTextColor(), except operates on just one line.
+	void drawLineColor(std::string str, int x, int y, const Uint32& color, int override_pointsize);
+
 public:
 	//! built-in font
 	static const char* defaultFont;
+
+	//! tab-width in spaces
+	static const int TAB_WIDTH = 4;
+	//! The following is basically a prerendered tab replacement...must be maintained to match tab_width. //TODO: Why even have TAB_WIDTH, then?
+	static constexpr char* TAB_REPLACE_STRING = "    ";
 
 	const char*		getName() const { return name.c_str(); }
 	FONScontext* 	getFontstash() { return fontstash; }
@@ -27,15 +38,29 @@ public:
 	int				getOutline() { return outlineSize; }
 
 	//! get the size of the given text string in pixels
+	//! implementation note: will split up a string by newlines and query sizeLine() per each substring/line.
 	//! @param str the utf-8 string to get the size of
 	//! @param out_w the integer to hold the width
 	//! @param out_h the integer to hold the height
+	//! @param override_pointsize a hack to let us reuse the same font for any point size...
 	//! @return 0 on success, non-zero on error
-	int sizeText(const char* str, int* out_w, int* out_h, int override_pointsize = 0) const;
+	int sizeText(std::string str, int* out_w, int* out_h, int override_pointsize = 0) const;
 
 	//! get the height of the font
 	//! @return the font height in pixels
 	int height(int override_pointsize = 0) const;
+
+	//! get the height a multiline string will take up
+	//! @param str the utf-8 string to get the height of
+	//! @param override_pointsize a hack to let us reuse the same font for any point size...
+	//! @return the font height in pixels
+	int textHeight(std::string str, int override_pointsize = 0) const;
+
+	//! get the width a multiline string will take up
+	//! @param str the utf-8 string to get the width of
+	//! @param override_pointsize a hack to let us reuse the same font for any point size...
+	//! @return the font width in pixels
+	int textWidth(std::string str, int override_pointsize = 0) const;
 
 	//! get a Font object from the engine
 	//! @param name The Font name
@@ -46,10 +71,21 @@ public:
 	static void dumpCache();
 
 	//! draws the text
+	//! @param str the utf-8 string to render
+	//! @param x the x coordinate from the left corner of the screen to render to.
+	//! @param y the y coordinate from the top of the screen to render to.
+	//! @param color the RGBA color value to render the text via.
+	//! @param override_pointsize a hack to let us reuse the same font for any point size...
 	void drawText(std::string str, int x, int y, int override_pointsize = 0);
 
 	//! draws the text with the given color
+	//! implementation note: will split up a string by newlines and draw them one at a time via drawLineColor() per each substring/line.
 	//TODO: Maybe we can hack Fontstash to support scaling, if we need it?
+	//! @param str the utf-8 string to render
+	//! @param x the x coordinate from the left corner of the screen to render to.
+	//! @param y the y coordinate from the top of the screen to render to.
+	//! @param color the RGBA color value to render the text via.
+	//! @param override_pointsize a hack to let us reuse the same font for any point size...
 	void drawTextColor(std::string str, int x, int y, const Uint32& color, int override_pointsize = 0); //TODO.
 
 private:

--- a/src/ui/Frame.cpp
+++ b/src/ui/Frame.cpp
@@ -328,14 +328,15 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			}
 
 			// get rendered text
-			Text* text = Text::get(entry.text.c_str(), font.c_str());
-			if (text == nullptr) {
+			Font* actualFont = Font::get(font.c_str());
+			if (actualFont == nullptr) {
 				continue;
 			}
 
 			// get the size of the rendered text
-			int textSizeW = text->getWidth();
-			int textSizeH = entrySize;
+			int textSizeW;
+			int textSizeH;// = entrySize;
+			actualFont->sizeText(entry.text.c_str(), &textSizeW, &textSizeH);
 
 			SDL_Rect pos;
 			pos.x = _size.x + border - scroll.x;
@@ -382,7 +383,7 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			if (scaledDest.h <= 0 || scaledDest.w <= 0) {
 				continue;
 			}
-			text->drawColor(src, scaledDest, entry.color);
+			actualFont->drawTextColor(entry.text, scaledDest.x, scaledDest.y, entry.color);
 		}
 	}
 
@@ -413,12 +414,12 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			if (font) {
 				int border = tooltip_border_width;
 
-				Text* text = Text::get(tooltip, font->getName());
 				SDL_Rect src;
 				src.x = mousex + 20 * ((float)Frame::virtualScreenX / xres);
 				src.y = mousey;
-				src.w = text->getWidth() + border * 2;
-				src.h = text->getHeight() + border * 2;
+				font->sizeText(tooltip, &src.w, &src.h);
+				src.w += border * 2;
+				src.h += border * 2;
 
 				SDL_Rect _src = src;
 				_src.x = _src.x * (float)xres / (float)Frame::virtualScreenX;
@@ -434,7 +435,7 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 				src2.h = src2.h * (float)yres / (float)Frame::virtualScreenY;
 				drawRect(&src2, tooltip_background, (Uint8)(tooltip_background>>mainsurface->format->Ashift));
 
-				text->drawColor(SDL_Rect{0,0,0,0}, src2, tooltip_text_color);
+				font->drawTextColor(tooltip, src2.x, src2.y, tooltip_text_color);
 			}
 		}
 	}

--- a/src/ui/Frame.cpp
+++ b/src/ui/Frame.cpp
@@ -336,7 +336,7 @@ void Frame::draw(SDL_Rect _size, SDL_Rect _actualSize) {
 			// get the size of the rendered text
 			int textSizeW;
 			int textSizeH;// = entrySize;
-			actualFont->sizeText(entry.text.c_str(), &textSizeW, &textSizeH);
+			actualFont->sizeText(entry.text, &textSizeW, &textSizeH);
 
 			SDL_Rect pos;
 			pos.x = _size.x + border - scroll.x;

--- a/src/ui/GameUI.cpp
+++ b/src/ui/GameUI.cpp
@@ -16,6 +16,8 @@
 
 #include <assert.h>
 
+float UI_SCALE_EXPERIMENT = 1.0f;
+
 static Frame* playerHud[MAXPLAYERS] = { nullptr };
 bool newui = false;
 

--- a/src/ui/Text.cpp
+++ b/src/ui/Text.cpp
@@ -70,7 +70,7 @@ void Text::drawColor(SDL_Rect src, SDL_Rect dest, const Uint32& color, int overr
 	//fonsSetSize(fontstash, 124.0f);
 	fonsSetColor(fontstash, color);
 
-	if (0 != font->sizeText(strToRender.c_str(), &width, &height))
+	if (0 != font->sizeText(strToRender, &width, &height))
 	{
 		std::cerr << "Failed to get size of text!\n"; //TODO: Delete debug!
 		return;


### PR DESCRIPTION
Still doesn't address some of the basic potential issues, such as no scaling support and..."different" caching (this may not be a bad thing)

Main difference with #583 is it basically obsoletes the Text class, as the caching and scaling features are not currently supported...
That said,
* This still doesn't support scaling.
* If we want to scale:
   * Hack Fontstash to support scaling
   * Make Fontstash render to an SDL surface/create a bitmap and load an SDL surface out of that, and recommission the Text class.

(I also properly configured font alignment, that needs to get backported)

I personally prefer this implementation if it meets our needs, since the interface for drawing text is simpler.
Might not be possible depending on if we need scaling and how hard it is to make it play nicely with that.

Silly OpenGL question: If I want to scale and pretend I'm at a different resolution (even if the rest of the game really isn't), is changing the OpenGL viewport settings sufficient when we set that up before our text render calls?