### PR TITLE
update actions/upload-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/build-linux_fmod_steam.yml
+++ b/.github/workflows/build-linux_fmod_steam.yml
@@ -41,7 +41,7 @@ jobs:
         ./build-linux_fmod_steam.sh
         
     - name: Upload Game Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: Game_fmod_steam # optional
@@ -49,7 +49,7 @@ jobs:
         path: build/release/barony
         
     - name: Upload Editor Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: Editor_fmod_steam # optional

--- a/.github/workflows/build-linux_fmod_steam_eos.yml
+++ b/.github/workflows/build-linux_fmod_steam_eos.yml
@@ -50,7 +50,7 @@ jobs:
         mv ../build/ ../build-editor/
         
     - name: Upload Game Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: Game_fmod_steam_eos # optional
@@ -58,7 +58,7 @@ jobs:
         path: build-barony/release/barony
         
     - name: Upload Editor Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: Editor_fmod_steam # optional


### PR DESCRIPTION
Updates the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):
> ## v3.1.2
> - Update all `@actions/*` NPM packages to their latest versions
> - Update all dev dependencies to their most recent versions
>
> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/upload-artifact` will generate some warning like in this run: https://github.com/TurningWheel/Barony/actions/runs/4728057408

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/upload-artifact`, because v3 uses Node.js 16.