### PR TITLE
Refactor stealth calculation for clarity and bugs

### DIFF
--- a/src/actmonster.cpp
+++ b/src/actmonster.cpp
@@ -4207,15 +4207,6 @@ void actMonster(Entity* my)
 
 							// skip if light level is too low and distance is too high
 							int light = entity->entityLightAfterReductions(*hitstats, my);
-							if ( (myStats->type >= LICH && myStats->type < KOBOLD) || myStats->type == LICH_FIRE || myStats->type == LICH_ICE || myStats->type == SHADOW )
-							{
-								//See invisible.
-								light = 1000;
-							}
-							else if ( myStats->type == SENTRYBOT || myStats->type == SPELLBOT )
-							{
-								light += 150;
-							}
 							double targetdist = sqrt( pow(my->x - entity->x, 2) + pow(my->y - entity->y, 2) );
 
 							real_t monsterVisionRange = sightranges[myStats->type];
@@ -4846,15 +4837,6 @@ void actMonster(Entity* my)
 			{
 				// skip if light level is too low and distance is too high
 				int light = entity->entityLightAfterReductions(*hitstats, my);
-				if ( (myStats->type >= LICH && myStats->type < KOBOLD) || myStats->type == LICH_FIRE || myStats->type == LICH_ICE || myStats->type == SHADOW )
-				{
-					//See invisible.
-					light = 1000;
-				}
-				else if ( myStats->type == SENTRYBOT || myStats->type == SPELLBOT )
-				{
-					light += 150;
-				}
 				double targetdist = sqrt( pow(my->x - entity->x, 2) + pow(my->y - entity->y, 2) );
 
 				real_t monsterVisionRange = sightranges[myStats->type];
@@ -5703,11 +5685,6 @@ timeToGoAgain:
 
 							// skip if light level is too low and distance is too high
 							int light = entity->entityLightAfterReductions(*hitstats, my);
-							if ( (myStats->type >= LICH && myStats->type < KOBOLD) || myStats->type == LICH_FIRE || myStats->type == LICH_ICE || myStats->type == SHADOW )
-							{
-								//See invisible.
-								light = 1000;
-							}
 							double targetdist = sqrt( pow(my->x - entity->x, 2) + pow(my->y - entity->y, 2) );
 
 							real_t monsterVisionRange = sightranges[myStats->type];

--- a/src/actplayer.cpp
+++ b/src/actplayer.cpp
@@ -3033,7 +3033,6 @@ void actPlayer(Entity* my)
 		if ( ticks % 4 == 0 )
 		{
 			int entityLight = my->entityLightAfterReductions(*stats[PLAYER_NUM], my);
-			entityLight = std::max(TOUCHRANGE, entityLight);
 			for ( int degree = 0; degree < 360; degree += 1 )
 			{
 				real_t rad = degree * PI / 180.0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7235,8 +7235,8 @@ int main(int argc, char** argv)
 					{
 						int light = players[clientnum]->entity->entityLight();
 						int tiles = light / 16;
-						int lightAfterReductions = std::max(TOUCHRANGE, 
-							players[clientnum]->entity->entityLightAfterReductions(*stats[clientnum], players[clientnum]->entity));
+						int lightAfterReductions =
+							players[clientnum]->entity->entityLightAfterReductions(*stats[clientnum], players[clientnum]->entity);
 						int tilesAfterReductions = lightAfterReductions / 16;
 						printTextFormatted(font8x8_bmp, 8, 44, "base light: %3d, tiles: %2d | modified light: %3d, tiles: %2d",
 							light, tiles, lightAfterReductions, tilesAfterReductions);


### PR DESCRIPTION
In reference to:
https://github.com/TurningWheel/Barony/issues/793

This PR does four things related to the light calculations for observers.
1. Fixes a couple defects in the existing function around negative perception scores and sneaking with zero skill in zero light.
2. Refactors the entityLightAfterReductions code to be a bit cleaner and easier to understand.
3. Pulls "See invisibility" code into entityLightAfterReductions so it isn't implemented in three separate places.
4. Removes redundant limiter on the debug tool for the light property which prevented it from correctly showing the bad light values caused by `#1`

Ultimately the new light calculations give basically identical values to the original. 
Detailed analysis below:

Notably, I did take special care to make sure these things **stayed exactly the same**
* In less than 48 light, with no observer, a non-sneaking, zero stealth player has 48 visibility (touchrange * 1.5)
* In less than 48 light, a 100 stealth (or invisible) player has 32 visibility. (touchrange)
* At zero stealth, your visibility is still equal to the ambient light level (when above TOUCHRANGE * 1.5 light level).
* Noise boxes still reduce effective visibility to 16 units
* Being observed by a monster that can see invisibility still forces you to 1000 visibility.
* Being observed by a monster that is blinded still forces TOUCHRANGE visibility.
* Sneaking / invisibility still has no impact on visibility when your stealth is at 100 (even though I think they should)
* Sentrybots and spellbots can still see enemies out to at least 150 units
* Dummybots still cannot be at less than 256 units of visibility
* The function can never return a value less than 16

The following things are **different**
* Only the quantity of light above 32 plus the observer perception can be reduced. (the net light level)
  * Sneaking reduces net light level by half (previously sneaking reduced the TOTAL light plus perception by half)
  * Stealth skill reduces net light level further by between 0 and 100%
* At 100 stealth, sneaking is no longer *worse* against enemies with negative perception scores.
* Lots of clamps exist to limit the return value, change the effects of lights, limit the impact of observer perception, etc.
* If a sentryBot ever managed to get into the HUNT state, it would still get the 150 sight bonus. (bug prevention)

The existing system was pretty wonky just due to the handling of negative values and the stacking multipliers. I tried really hard to separate all the intents and functionalities into their own little clamps and values so it could be tweaked easily. The code, as it stands, is as close as I could get it to the original (minus bugs).

The end result is dang close to what the actual **effect** of the original code was, minus the bugs. If it doesn't match up with what y'all intended the effect to be, it should be real easy to tweak now.