### PR TITLE
Make BARONY_SUPER_MULTIPLAYER functional

### DIFF
--- a/src/game.hpp
+++ b/src/game.hpp
@@ -35,7 +35,7 @@ class Entity;
 
 #define DEBUG 1
 #define ENTITY_PACKET_LENGTH 46
-#define NET_PACKET_SIZE 512
+#define NET_PACKET_SIZE 1024
 
 // impulses (bound keystrokes, mousestrokes, and joystick/game controller strokes) //TODO: Player-by-player basis.
 extern Uint32 impulses[NUMIMPULSES];

--- a/src/interface/playerinventory.cpp
+++ b/src/interface/playerinventory.cpp
@@ -1985,7 +1985,24 @@ std::string getItemSpritePath(const int player, Item& item)
 			}
 			else
 			{
-				imagePathsNode = list_Node(&items[item.type].images, item.getLootBagPlayer());
+				int playerOwner = item.getLootBagPlayer();
+				Uint32 index = playerOwner;
+				switch (playerOwner)
+				{
+					case 5:
+						index = 2;
+						break;
+					case 6:
+						index = 3;
+						break;
+					case 7:
+						index = 4;
+						break;
+					default:
+						break;
+				}
+
+				imagePathsNode = list_Node(&items[item.type].images, index);
 			}
 		}
 		else

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -989,7 +989,24 @@ Sint32 itemModel(const Item* const item)
 		}
 		else
 		{
-			return items[item->type].index + item->getLootBagPlayer();
+			int playerOwner = item->getLootBagPlayer();
+			Uint32 index = playerOwner;
+			switch (playerOwner)
+			{
+				case 5:
+					index = 2;
+					break;
+				case 6:
+					index = 3;
+					break;
+				case 7:
+					index = 4;
+					break;
+				default:
+					break;
+			}
+
+			return items[item->type].index + index;
 		}
 	}
 	return items[item->type].index + item->appearance % items[item->type].variations;
@@ -1078,7 +1095,24 @@ SDL_Surface* itemSprite(Item* const item)
 			}
 			else
 			{
-				node = list_Node(&items[item->type].surfaces, item->getLootBagPlayer());
+				int playerOwner = item->getLootBagPlayer();
+				Uint32 index = playerOwner;
+				switch (playerOwner)
+				{
+					case 5:
+						index = 2;
+						break;
+					case 6:
+						index = 3;
+						break;
+					case 7:
+						index = 4;
+						break;
+					default:
+						break;
+				}
+
+				node = list_Node(&items[item->type].surfaces, index);
 			}
 		}
 		else

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1417,7 +1417,7 @@ void sendAllyCommandClient(int player, Uint32 uid, int command, Uint8 x, Uint8 y
 	sendPacket(net_sock, -1, net_packet, 0);
 }
 
-NetworkingLobbyJoinRequestResult lobbyPlayerJoinRequest(int& outResult, bool lockedSlots[4])
+NetworkingLobbyJoinRequestResult lobbyPlayerJoinRequest(int& outResult, bool lockedSlots[MAXPLAYERS])
 {
     printlog("processing lobby join request\n");
 

--- a/src/net.hpp
+++ b/src/net.hpp
@@ -65,7 +65,7 @@ enum NetworkingLobbyJoinRequestResult : int
 	NET_LOBBY_JOIN_DIRECTIP_FAILURE,
 	NET_LOBBY_JOIN_DIRECTIP_SUCCESS
 };
-NetworkingLobbyJoinRequestResult lobbyPlayerJoinRequest(int& outResult, bool lockedSlots[4]);
+NetworkingLobbyJoinRequestResult lobbyPlayerJoinRequest(int& outResult, bool lockedSlots[MAXPLAYERS]);
 Entity* receiveEntity(Entity* entity);
 void clientActions(Entity* entity);
 void clientHandleMessages(Uint32 framerateBreakInterval);

--- a/src/playfab.hpp
+++ b/src/playfab.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
 #include "main.hpp"
+#include "stat.hpp"
+#include "scores.hpp"
+
+#ifdef USE_PLAYFAB
+
 #include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabClientDataModels.h>
 #include <playfab/PlayFabClientInstanceApi.h>
@@ -9,10 +14,6 @@
 #include <playfab/PlayFabCloudScriptApi.h>
 #include <playfab/PlayFabCloudScriptDataModels.h>
 #include <playfab/PlayFabCloudScriptInstanceApi.h>
-#include "stat.hpp"
-#include "scores.hpp"
-
-#ifdef USE_PLAYFAB
 
 class PlayfabUser_t
 {

--- a/src/ui/GameUI.cpp
+++ b/src/ui/GameUI.cpp
@@ -3695,6 +3695,27 @@ std::vector<std::vector<std::string>> playerXPCapPaths = {
 		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04b.png",
 		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04c.png",
 		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04d.png",
+	},
+	{
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_02.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_02a.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_02b.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_02c.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_02d.png",
+	},
+	{
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_03.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_03a.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_03b.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_03c.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_03d.png",
+	},
+	{
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04a.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04b.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04c.png",
+		"*#images/ui/HUD/xpbar/HUD_Exp_SandCap_04d.png",
 	}
 };
 
@@ -3742,6 +3763,18 @@ void createXPBar(const int player)
 				break;
 			case 3:
 				bodyPath += "03.png";
+				break;
+			case 4:
+				bodyPath += "04.png";
+				break;
+			case 5:
+				bodyPath += "02.png";
+				break;
+			case 6:
+				bodyPath += "03.png";
+				break;
+			case 7:
+				bodyPath += "04.png";
 				break;
 		}
 	}


### PR DESCRIPTION
This PR fixes issues with the precompiler directive `BARONY_SUPER_MULTIPLAYER` and makes it functional (though still buggy). I do not have Steamworks or EOS so this has only been tested both with multiple local instances and LAN mode with port forwarding over internet.

Fixes:
- Previously, loading an existing save would not work. This is due to `NET_PACKET_SIZE` being larger than the packet data used to load an existing 8 player save. [The `chunk_size` in `lobbyPlayerJoinRequest()` is 98 bytes](https://github.com/TurningWheel/Barony/blob/b5cb1cc5ceb6ef79634bcb17ad86ac9fd46e1e03/src/net.cpp#L1543), and the packet length is defined as `8 + MAXPLAYERS * chunk_size`, resulting in a total of 792 bytes. The old `NET_PACKET_SIZE` is 512, which is too small. I'm not sure what's a good number so I just doubled it.
- There aren't any assets for death boxes past player 5, which resulted in death boxes showing up as doors that would block vision. I simply reused the assets for players 2-4 to make it playable.
- I was having compilation errors with `USE_PLAYFAB` off since I didn't have the libraries/includes, so I moved the includes underneath it.

Bugs:
- There are no assets for death boxes past player 5, so the death box asset colors and player name colors don't match up. I don't have experience with making assets and I don't believe the license granted for this repo allows us to reuse/redistribute assets, so I haven't created new assets.
- Players past player 4 will be invisible on the lobby menu, but there are no issues with character creation or once in game.
- Occasionally there players will desync. I haven't taken a look at how the netcode works to investigate this.