### PR TITLE
[WIP] Enable back support for OpenAL

### DIFF
--- a/src/engine/audio/defines.cpp
+++ b/src/engine/audio/defines.cpp
@@ -78,4 +78,6 @@ bool sfxUseDynamicAmbientVolume = true;
 bool sfxUseDynamicEnvironmentVolume = true;
 
 void* fmod_extraDriverData = nullptr;
-#endif //USE_FMOD
+#elif defined OPENAL_ENABLED
+OPENAL_BUFFER** intromusic = nullptr;
+#endif

--- a/src/engine/audio/music.cpp
+++ b/src/engine/audio/music.cpp
@@ -75,6 +75,9 @@ bool loadMusic()
         intromusic = (FMOD::Sound**)malloc(sizeof(FMOD::Sound*) * NUMINTROMUSIC);
         memset(intromusic, 0, sizeof(FMOD::Sound*) * NUMINTROMUSIC);
     }
+#elif defined USE_OPENAL
+	// TODO: load intro music
+
 #endif
 
     bool introMusicChanged;

--- a/src/engine/audio/sound.cpp
+++ b/src/engine/audio/sound.cpp
@@ -29,18 +29,21 @@
 #endif
 #endif
 
+
+void setGlobalVolume(real_t master, real_t music, real_t gameplay, real_t ambient, real_t environment, real_t notification)
+{
 #ifdef USE_FMOD
 #elif defined USE_OPENAL
 #else
-void setGlobalVolume(real_t master, real_t music, real_t gameplay, real_t ambient, real_t environment, real_t notification)
-{
-	return;
+#endif
 }
 void setAudioDevice(const std::string& device) 
 {
-	return;
-}
+#ifdef USE_FMOD
+#elif defined USE_OPENAL
+#else
 #endif
+}
 
 #ifdef USE_FMOD
 
@@ -328,36 +331,6 @@ void sound_update(int player, int index, int numplayers)
 
 #elif defined USE_OPENAL
 
-struct OPENAL_BUFFER {
-	ALuint id;
-	bool stream;
-	char oggfile[64];
-};
-struct OPENAL_SOUND {
-	ALuint id;
-	OPENAL_CHANNELGROUP *group;
-	float volume;
-	OPENAL_BUFFER *buffer;
-	bool active;
-	char* oggdata;
-	int oggdata_length;
-	int ogg_seekoffset;
-	OggVorbis_File oggStream;
-	vorbis_info* vorbisInfo;
-	vorbis_comment* vorbisComment;
-	ALuint streambuff[4];
-	bool loop;
-	bool stream_active;
-	int indice;
-};
-
-struct OPENAL_CHANNELGROUP {
-	float volume;
-	int num;
-	int cap;
-	OPENAL_SOUND **sounds;
-};
-
 SDL_mutex *openal_mutex;
 
 static size_t openal_oggread(void* ptr, size_t size, size_t nmemb, void* datasource) {
@@ -513,14 +486,12 @@ ALCdevice  *openal_device = nullptr;
 //#define openal_maxchannels 100
 
 OPENAL_BUFFER** sounds = nullptr;
-Uint32 numsounds = 0;
 OPENAL_BUFFER** minesmusic = NULL;
 OPENAL_BUFFER** swampmusic = NULL;
 OPENAL_BUFFER** labyrinthmusic = NULL;
 OPENAL_BUFFER** ruinsmusic = NULL;
 OPENAL_BUFFER** underworldmusic = NULL;
 OPENAL_BUFFER** hellmusic = NULL;
-OPENAL_BUFFER** intromusic = NULL;
 OPENAL_BUFFER* intermissionmusic = NULL;
 OPENAL_BUFFER* minetownmusic = NULL;
 OPENAL_BUFFER* splashmusic = NULL;
@@ -1266,7 +1237,7 @@ void physfsReloadMusic(bool &introMusicChanged, bool reloadAll) //TODO: This sho
 	{
 		return;
 	}
-#ifdef SOUND
+#ifdef SOUNDsdfdsf
 
 	std::vector<std::string> themeMusic;
 	themeMusic.push_back("music/introduction.ogg");
@@ -1714,13 +1685,13 @@ void physfsReloadMusic(bool &introMusicChanged, bool reloadAll) //TODO: This sho
 #endif // SOUND
 }
 
+/**
+ * Free custom music slots, not used by official music assets.
+ */
 void gamemodsUnloadCustomThemeMusic()
 {
 #ifdef SOUND
-#ifdef USE_OPENAL
-#define FMOD_Sound_Release OPENAL_Sound_Release
-#endif
-	// free custom music slots, not used by official music assets.
+#ifdef FMOD_ENABLED
 	if ( gnomishminesmusic )
 	{
 		gnomishminesmusic->release();
@@ -1751,8 +1722,9 @@ void gamemodsUnloadCustomThemeMusic()
 		hamletmusic->release();
 		hamletmusic = nullptr;
 	}
+#endif
 #ifdef USE_OPENAL
-#undef FMOD_Sound_Release
+
 #endif
 #endif // !SOUND
 }

--- a/src/engine/audio/sound_game.cpp
+++ b/src/engine/audio/sound_game.cpp
@@ -397,6 +397,17 @@ OPENAL_SOUND* playSoundPlayer(int player, Uint16 snd, Uint8 vol)
 	return NULL;
 }
 
+OPENAL_SOUND* playSoundNotificationPlayer(int player, Uint16 snd, Uint8 vol)
+{
+	if (no_sound)
+	{
+		return NULL;
+	}
+
+	//TODO: Implement playSoundNotificationPlayer for OpenAL.
+	return NULL;
+}
+
 /*-------------------------------------------------------------------------------
 
 	playSoundPos
@@ -575,6 +586,16 @@ OPENAL_SOUND* playSound(Uint16 snd, Uint8 vol)
 	return channel;
 }
 
+OPENAL_SOUND* playSoundNotification(Uint16 snd, Uint8 vol)
+{
+	if (no_sound)
+	{
+		return NULL;
+	}
+	// TODO: Implement playSoundNotification for OpenAL
+	return NULL;
+}
+
 void playMusic(OPENAL_BUFFER* sound, bool loop, bool crossfade, bool resume)
 {
 	if (no_sound)
@@ -636,15 +657,15 @@ void playMusic(OPENAL_BUFFER* sound, bool loop, bool crossfade, bool resume)
 	OPENAL_Channel_Play(music_channel);
 }
 
-bool shopmusicplaying = false;
-bool combatmusicplaying = false;
-bool minotaurmusicplaying = false;
-bool herxmusicplaying = false;
-bool devilmusicplaying = false;
-bool olddarkmap = false;
-bool sanctummusicplaying = false;
+extern bool shopmusicplaying;
+extern bool combatmusicplaying;
+extern bool minotaurmusicplaying;
+extern bool herxmusicplaying;
+extern bool devilmusicplaying;
+extern bool olddarkmap;
+extern bool sanctummusicplaying;
 
-int currenttrack = -1;
+extern int currenttrack;
 
 void handleLevelMusic()
 {

--- a/src/init_game.cpp
+++ b/src/init_game.cpp
@@ -551,6 +551,7 @@ void deinitGame()
 #endif
 	if ( !no_sound )
 	{
+#ifdef USE_FMOD
 		music_channel->stop();
 		music_channel2->stop();
 		introductionmusic->release();
@@ -655,7 +656,11 @@ void deinitGame()
 		{
 			free(intromusic);
 		}
+#elif defined OPENAL_ENABLED
+	// TODO: unload OpenAL resources
+#endif
 	}
+
 #ifdef USE_OPENAL
 #undef FMOD_Channel_Stop
 #undef FMOD_Sound_Release

--- a/src/mod_tools.cpp
+++ b/src/mod_tools.cpp
@@ -9277,7 +9277,7 @@ void Mods::unloadMods(bool force)
 		physfsReloadMusic(reloadIntroMusic, true);
 		if (reloadIntroMusic)
 		{
-#ifdef SOUND
+#ifdef MUSIC
 			playMusic(intromusic[local_rng.rand() % (NUMINTROMUSIC - 1)], false, true, true);
 #endif			
 		}
@@ -9403,7 +9403,7 @@ void Mods::loadMods()
 		physfsReloadMusic(reloadIntroMusic, false);
 		if ( reloadIntroMusic )
 		{
-#ifdef SOUND
+#ifdef MUSIC
 			playMusic(intromusic[local_rng.rand() % (NUMINTROMUSIC - 1)], false, true, true);
 #endif			
 		}
@@ -9416,7 +9416,7 @@ void Mods::loadMods()
 		physfsReloadMusic(reloadIntroMusic, true);
 		if ( reloadIntroMusic )
 		{
-#ifdef SOUND
+#ifdef MUSIC
 			playMusic(intromusic[local_rng.rand() % (NUMINTROMUSIC - 1)], false, true, true);
 #endif			
 		}
@@ -9426,7 +9426,7 @@ void Mods::loadMods()
 	updateLoadingScreen(70);
 	doLoadingScreen();
 
-	std::string langDirectory = PHYSFS_getRealDir("lang/en.txt");
+	std::string langDirectory = PHYSFS_getRealDir("lang/fr.txt");
 	if ( langDirectory.compare("./") != 0 )
 	{
 		if ( Language::reloadLanguage() != 0 )

--- a/src/ui/MainMenu.cpp
+++ b/src/ui/MainMenu.cpp
@@ -2856,12 +2856,14 @@ namespace MainMenu {
             fpsLimit = std::min(std::max(MIN_FPS, *cvar_desiredFps), MAX_FPS);
         }
 		current_audio_device = audio_device;
+#if FMOD_ENABLED
         if (fmod_speakermode != speaker_mode) {
             fmod_speakermode = (FMOD_SPEAKERMODE)speaker_mode;
             if (initialized) {
                 restartPromptRequired = true;
             }
         }
+#endif
 		MainMenu::master_volume = std::min(std::max(0.f, master_volume / 100.f), 1.f);
 		sfxvolume = std::min(std::max(0.f, gameplay_volume / 100.f), 1.f);
 		sfxAmbientVolume = std::min(std::max(0.f, ambient_volume / 100.f), 1.f);
@@ -2960,7 +2962,9 @@ namespace MainMenu {
 		settings.fov = ::fov;
 		settings.fps = *cvar_desiredFps;
 		settings.audio_device = current_audio_device;
+#ifdef FMOD_ENABLED
         settings.speaker_mode = (int)fmod_speakermode;
+#endif
 		settings.master_volume = MainMenu::master_volume * 100.f;
 		settings.gameplay_volume = (float)sfxvolume * 100.f;
 		settings.ambient_volume = (float)sfxAmbientVolume * 100.f;
@@ -6313,9 +6317,9 @@ bind_failed:
 		}
 		int y = 0;
 
+		int num_drivers = 0;
 #if !defined(NINTENDO) && defined(USE_FMOD)
 		int selected_device = 0;
-		int num_drivers = 0;
 		(void)fmod_system->getNumDrivers(&num_drivers);
 		audio_drivers.clear();
 		audio_drivers.reserve(num_drivers);
@@ -24690,9 +24694,10 @@ failed:
 
 				// return to title screen
 		        destroyMainMenu();
-#ifdef SOUND
+#ifdef MUSIC
 				const int music = RNG.uniform(0, NUMINTROMUSIC - 2);
-	            playMusic(intromusic[music], true, false, false);
+				printlog("before play.\n");
+	            //playMusic(intromusic[music], true, false, false);
 #endif
 				createTitleScreen();
 
@@ -24723,7 +24728,7 @@ failed:
 
 				// return to menu
 				destroyMainMenu();
-#ifdef SOUND
+#ifdef MUSIC
 				const int music = RNG.uniform(0, NUMINTROMUSIC - 2);
 	            playMusic(intromusic[music], true, false, false);
 #endif
@@ -24758,7 +24763,7 @@ failed:
                     // create a highscore as token of remembrance.
                     doEndgame(true);
                 }
-#ifdef SOUND
+#ifdef MUSIC
                 const int music = RNG.uniform(0, NUMINTROMUSIC - 2);
                 playMusic(intromusic[music], true, false, false);
 #endif
@@ -24790,7 +24795,7 @@ failed:
 				destroyMainMenu();
 				createDummyMainMenu();
 				createCreditsScreen(true);
-#ifdef SOUND
+#ifdef MUSIC
 	            playMusic(intromusic[0], true, false, false);
 #endif
 
@@ -24981,9 +24986,11 @@ failed:
 	}
 
 	void doMainMenu(bool ingame) {
+		printlog("mmenu 1\n");
         if (video_refresh) {
 			Frame::guiResize(0, 0); // resize gui for new aspect ratio
             createMainMenu(!intro);
+			printlog("mmenu 2\n");
             
 #if defined(VIDEO_RESTART_NEEDED)
             // return to settings button
@@ -25073,7 +25080,7 @@ failed:
             // at the end so that old_video is not overwritten
             video_refresh = VideoRefresh::None;
         }
-
+		printlog("mmenu 3\n");
 		if (!main_menu_frame) {
 		    if (ingame) {
 		        if (movie || fadeout) {
@@ -25086,7 +25093,7 @@ failed:
 			}
 			assert(main_menu_frame);
 		}
-
+		printlog("mmenu 4\n");
         // update a few things every tick
 #ifdef NINTENDO
 		enabledDLCPack1 = nxCheckDLC(0);
@@ -25144,22 +25151,23 @@ failed:
 			}
 #endif
         }
-
+		printlog("mmenu 4\n");
         // if no controller is connected, you can always connect one just for the main menu.
         if (!ingame && currentLobbyType == LobbyType::None) {
             if (!inputs.hasController(getMenuOwner())) {
                 Input::waitingToBindControllerForPlayer = getMenuOwner();
             }
         }
-
+		printlog("mmenu 5\n");
 		// hide mouse if we're driving around with a controller
         auto cmouse = inputs.getVirtualMouse(inputs.getPlayerIDAllowedKeyboard());
         cmouse->draw_cursor = isMouseVisible();
-
+		printlog("mmenu 6\n");
 		static ConsoleVariable<bool> cvar_disableFadeFinished("/test_disable_fade_finished", false);
 		if (fadeout && fadealpha >= 255 && !*cvar_disableFadeFinished) {
             handleFadeFinished(ingame);
         }
+		printlog("mmenu 7\n");
 	}
 
 	static std::string getVersionString() {


### PR DESCRIPTION
Fix a few misalignments between the code for FMod and OpenAL.

The reason is that the FMod code changed a bit and the part that supports OpenAL was not modified.

**Disclaimer it's a work in progress**
For now, it allows us to compile with OpenAL and have sound support without any crashes (tested on Linux, test for Windows will happen this week).
More commit will be added to this branch to support music.
I'm trying to minimize the changes to have a digest PR, don't shoot me to not fix everything around sound/music :)

What I found:
1) sometimes instead of using `#ifdef SOUND` we need `#ifdef MUSIC`
2) some parts are just missing maintenance, for ex:
   - ex: when some variables were moved for FMod, the variables for OpenAL were not
   - some functions were added for FMod but not for OpenAL (like playSoundNotificationPlayer)