### PR TITLE
Fix incorrect uses of `ifdef` for `USE_FMOD` [#691]

### DIFF
--- a/src/ui/MainMenu.cpp
+++ b/src/ui/MainMenu.cpp
@@ -2869,6 +2869,7 @@ namespace MainMenu {
         } else {
             fpsLimit = std::min(std::max(MIN_FPS, *cvar_desiredFps), MAX_FPS);
         }
+		#if defined(USE_FMOD)
 		current_audio_device = audio_device;
         if (fmod_speakermode != speaker_mode) {
             fmod_speakermode = (FMOD_SPEAKERMODE)speaker_mode;
@@ -2876,6 +2877,7 @@ namespace MainMenu {
                 restartPromptRequired = true;
             }
         }
+		#endif
 		MainMenu::master_volume = std::min(std::max(0.f, master_volume / 100.f), 1.f);
 		sfxvolume = std::min(std::max(0.f, gameplay_volume / 100.f), 1.f);
 		sfxAmbientVolume = std::min(std::max(0.f, ambient_volume / 100.f), 1.f);
@@ -2974,7 +2976,9 @@ namespace MainMenu {
 		settings.fov = ::fov;
 		settings.fps = *cvar_desiredFps;
 		settings.audio_device = current_audio_device;
+		#if defined(USE_FMOD)
         settings.speaker_mode = (int)fmod_speakermode;
+		#endif
 		settings.master_volume = MainMenu::master_volume * 100.f;
 		settings.gameplay_volume = (float)sfxvolume * 100.f;
 		settings.ambient_volume = (float)sfxAmbientVolume * 100.f;
@@ -6357,9 +6361,10 @@ bind_failed:
 		}
 		int y = 0;
 
+int num_drivers = 0;
 #if !defined(NINTENDO) && defined(USE_FMOD)
 		int selected_device = 0;
-		int num_drivers = 0;
+		num_drivers = 0;
 		(void)fmod_system->getNumDrivers(&num_drivers);
 		audio_drivers.clear();
 		audio_drivers.reserve(num_drivers);


### PR DESCRIPTION
# Issue #691

When compiling using the following command:

```sh
cmake -DCMAKE_BUILD_TYPE=Release -DOPENAL_ENABLED=OFF -DFMOD_ENABLED=OFF ..
```

Gives following error:

```sh
[ 94%] Building CXX object CMakeFiles/barony.dir/src/engine/audio/init_audio.cpp.o
repos/Barony/src/ui/MainMenu.cpp: In member function ‘int MainMenu::AllSettings::save()’:
repos/Barony/src/ui/MainMenu.cpp:2873:13: error: ‘fmod_speakermode’ was not declared in this scope; did you mean ‘speaker_mode’?
 2873 |         if (fmod_speakermode != speaker_mode) {
      |             ^~~~~~~~~~~~~~~~
      |             speaker_mode
repos/Barony/src/ui/MainMenu.cpp:2874:33: error: ‘FMOD_SPEAKERMODE’ was not declared in this scope
 2874 |             fmod_speakermode = (FMOD_SPEAKERMODE)speaker_mode;
      |                                 ^~~~~~~~~~~~~~~~
repos/Barony/src/ui/MainMenu.cpp: In static member function ‘static MainMenu::AllSettings MainMenu::AllSettings::load(bool)’:
repos/Barony/src/ui/MainMenu.cpp:2977:38: error: ‘fmod_speakermode’ was not declared in this scope; did you mean ‘speaker_mode’?
 2977 |         settings.speaker_mode = (int)fmod_speakermode;
      |                                      ^~~~~~~~~~~~~~~~
      |                                      speaker_mode
repos/Barony/src/ui/MainMenu.cpp: In function ‘void MainMenu::settingsAudio(Button&)’:
repos/Barony/src/ui/MainMenu.cpp:6445:22: error: ‘num_drivers’ was not declared in this scope
 6445 |                 if ( num_drivers > 0 )
      |  
```

- [X] Fix `ifdef` to `USE_FMOD`.
- [X] Correct the declaration of the variable `num_drivers` which was inaccessible in some cases.