### PR TITLE
Update Github Actions to v4

### DIFF
--- a/.github/workflows/build-linux_fmod_steam.yml
+++ b/.github/workflows/build-linux_fmod_steam.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Actually does the build...
     - name: Update apt repository
@@ -41,7 +41,7 @@ jobs:
         ./build-linux_fmod_steam.sh
         
     - name: Upload Game Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Game_fmod_steam # optional
@@ -49,7 +49,7 @@ jobs:
         path: build/release/barony
         
     - name: Upload Editor Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4  
       with:
         # Artifact name
         name: Editor_fmod_steam # optional

--- a/.github/workflows/build-linux_fmod_steam_eos.yml
+++ b/.github/workflows/build-linux_fmod_steam_eos.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Actually does the build...
     - name: Update apt repository
@@ -50,7 +50,7 @@ jobs:
         mv ../build/ ../build-editor/
         
     - name: Upload Game Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Game_fmod_steam_eos # optional
@@ -58,7 +58,7 @@ jobs:
         path: build-barony/release/barony
         
     - name: Upload Editor Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Editor_fmod_steam # optional


### PR DESCRIPTION
Github Actions v3 has been deprecated since January as such I believe you should update it to v4 given how simple it should be, given ever since your actions have been failing ever since.