### PR TITLE
Improve build instructions for Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,13 @@ If you'd rather debug the editor, instead of hitting the green play button up to
 ## Acquire Dependencies
 
 For Debian/Ubuntu, you should be able to install most of these dependencies with: //TODO: Add OpenAL to the list.
+```
 sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libpng-dev libz-dev libphysfs-dev rapidjson-dev
+```
+For Arch:
+```
+yay -S --needed sdl2-compat sdl2_image sdl2_net sdl2_ttf libpng physfs rapidjson openal cmake3
+```
 
 You will also need PhysFS v3.0.1 for Barony v3.1.5+ if not available in your distro's package repository.
 Linux Install (Navigate to somewhere to drop install files first):
@@ -103,7 +109,7 @@ You can do something along the following lines:
 mkdir build
 cd build
 cmake ..
-make -j
+make -j$(nproc)
 ```
 
 # Build Flags


### PR DESCRIPTION
- `make -j` takes down my system because it runs out of memmory, so it's better to replace it with `make -j$(nproc)`, it'll give `make` the amount of cores available on the system. https://stackoverflow.com/questions/11639524/make-j-ram-limits
- Added list of packages for Arch (`yay` is used instead of `pacman` because cmake3 is not available in official Arch repositories and cmake 4 dropped compatibility for cmake <3.5)
- Formatted list of packages for Debian/Ubuntu