### PR TITLE
Add FMOD install instruction for linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,6 +96,8 @@ Linux Install (Navigate to somewhere to drop install files first):
  * make install
 You can then remove the installation files.
 
+For FMOD, you will need to go to https://www.fmod.com/download, select and download the 2.02.14 version, unpack it anywhere and set the environment variable `FMOD_DIR` to the directory where you unpacked it.
+
 ## Building Barony
 
 You can do something along the following lines:


### PR DESCRIPTION
Even when I choose OpenAL over FMOD, I do get compile errors, which suggests that FMOD might currently be a hard dependency regardless.

Using the most recent version of FMOD introduced different compile errors. So I went digging on the discord and found that a specific version is needed. As soon as I used the correct version, the game compiled. So I figured it would be nice to have this noted in the instructions as it appears to be an essential step to build the game on linux.