### PR TITLE
Tweaked to preserve myconid and dryad buff

### DIFF
--- a/src/charclass.cpp
+++ b/src/charclass.cpp
@@ -3373,16 +3373,15 @@ void initClass(const int player)
 	}
 
 	if ( stats[player]->stat_appearance == 0 
-		&& (stats[player]->playerRace == RACE_DRYAD || stats[player]->playerRace == RACE_MYCONID)
-		&& !stats[player]->helmet )
+		&& ( stats[player]->playerRace == RACE_DRYAD || stats[player]->playerRace == RACE_MYCONID) )
 	{
+		if (stats[player]->helmet && stats[player]->helmet->canUnequip())
+		{
+			useItem(stats[player]->helmet, player);
+		}
+
 		stats[player]->setEffectActive(EFF_GROWTH, 3);
 		stats[player]->EFFECTS_TIMERS[EFF_GROWTH] = -1;
-	}
-	else
-	{
-		stats[player]->clearEffect(EFF_GROWTH);
-		stats[player]->EFFECTS_TIMERS[EFF_GROWTH] = 0;
 	}
 
 	if ( stats[player]->stat_appearance == 0 && stats[player]->playerRace == RACE_AUTOMATON )


### PR DESCRIPTION
Tweaked the code in class initialisation to not equip helmets on myconids and dryads to preserve the growth buff at the start of the game.

I found many not picking classes that started with helmets because of this. The change is just to encourage myconids and dryads to use other classes without problems.